### PR TITLE
Store root template repo info in project settings

### DIFF
--- a/packages/skaff-lib/src/actions/template/load-project-template-revision.ts
+++ b/packages/skaff-lib/src/actions/template/load-project-template-revision.ts
@@ -1,32 +1,34 @@
 import { Result } from "../../lib";
 import { logError } from "../../lib/utils";
 import { Project, Template } from "../../models";
-import {
-  getRootTemplateRepository
-} from "../../repositories";
+import { getRootTemplateRepository } from "../../repositories";
 
 export async function loadProjectTemplateRevision(
   project: Project,
 ): Promise<Result<Template | null>> {
   const rootTemplateRepository = await getRootTemplateRepository();
 
-  const rootTemplateName =
-    project.instantiatedProjectSettings.rootTemplateName;
-  const rootInst =
-    project.instantiatedProjectSettings.instantiatedTemplates[0];
+  const rootTemplateName = project.instantiatedProjectSettings.rootTemplateName;
+  const rootInst = project.instantiatedProjectSettings.instantiatedTemplates[0];
   const commitHash = rootInst?.templateCommitHash;
 
   if (!commitHash) {
     logError({
       shortMessage: `No commit hash found for project ${project.instantiatedProjectSettings.projectName}`,
     });
-    return { error: `No commit hash found for project ${project.instantiatedProjectSettings.projectName}` };
+    return {
+      error: `No commit hash found for project ${project.instantiatedProjectSettings.projectName}`,
+    };
   }
 
-  if (rootInst?.templateRepoUrl) {
+  const repoUrl = rootInst?.templateRepoUrl ?? project.rootTemplate.repoUrl;
+  const branch =
+    rootInst?.templateBranch ?? project.rootTemplate.branch ?? "main";
+
+  if (repoUrl) {
     const addResult = await rootTemplateRepository.addRemoteRepo(
-      rootInst.templateRepoUrl,
-      rootInst.templateBranch ?? "main",
+      repoUrl,
+      branch,
     );
     if ("error" in addResult) {
       return addResult;

--- a/packages/skaff-lib/src/services/project-settings-service.ts
+++ b/packages/skaff-lib/src/services/project-settings-service.ts
@@ -1,14 +1,16 @@
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import { Template } from "../models/template";
-import {
-  Result,
-} from "../lib/types";
+import { Result } from "../lib/types";
 import { makeDir } from "./file-service";
 import { deepSortObject } from "../utils/shared-utils";
 import { logError } from "../lib/utils";
 import { getRootTemplateRepository } from "../repositories";
-import { InstantiatedTemplate, ProjectSettings, projectSettingsSchema } from "@timonteutelink/template-types-lib";
+import {
+  InstantiatedTemplate,
+  ProjectSettings,
+  projectSettingsSchema,
+} from "@timonteutelink/template-types-lib";
 
 export async function writeNewProjectSettings(
   absoluteProjectPath: string,
@@ -139,8 +141,7 @@ export async function loadProjectSettings(
   }
 
   // TODO here we would also load other reference template repos. For now all templates of a root template need to be in same repo.
-  const rootInstantiated =
-    finalProjectSettings.data.instantiatedTemplates[0];
+  const rootInstantiated = finalProjectSettings.data.instantiatedTemplates[0];
   const instantiatedRootTemplateCommitHash =
     rootInstantiated?.templateCommitHash;
 
@@ -179,6 +180,16 @@ export async function loadProjectSettings(
     return {
       error: `Root template ${finalProjectSettings.data.rootTemplateName} not found`,
     };
+  }
+
+  // Ensure project settings store the repo information of the root template
+  if (rootInstantiated) {
+    if (rootTemplate.data.repoUrl) {
+      rootInstantiated.templateRepoUrl = rootTemplate.data.repoUrl;
+    }
+    if (rootTemplate.data.branch) {
+      rootInstantiated.templateBranch = rootTemplate.data.branch;
+    }
   }
 
   for (const subTemplateSettings of finalProjectSettings.data


### PR DESCRIPTION
## Summary
- ensure generated projects persist root template repo URL and branch
- keep root template repo info when loading project settings
- fall back to root template's repo when resolving project revisions

## Testing
- `npm test` (packages/skaff-lib) *(fails: moduleFileExtensions must include 'js')*
- `npm test` (apps/cli) *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ed910c008325ad196dfa5c5d4d74