### PR TITLE
Tidy dialog form handling

### DIFF
--- a/apps/web/src/components/general/git-repo-selection-dialog.tsx
+++ b/apps/web/src/components/general/git-repo-selection-dialog.tsx
@@ -9,87 +9,135 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import {Input} from "@/components/ui/input";
+import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { useCallback, useState } from "react";
+import { Label } from "@/components/ui/label";
+import { FormEvent, useCallback, useState } from "react";
 
 interface GitRepoSelectionDialogProps {
-	buttonText: string
-	actionText: string
+  buttonText: string;
+  actionText: string;
 
   onConfirm: (repoUrl: string, branch: string) => Promise<void>;
   onCancel?: () => Promise<void>;
 }
 
 export const GitRepoSelectionDialog: React.FC<GitRepoSelectionDialogProps> = ({
-	buttonText,
-	actionText,
+  buttonText,
+  actionText,
   onConfirm,
   onCancel,
 }) => {
   const [open, setOpen] = useState(false);
-	const [githubUrl, setGithubUrl] = useState("");
-	const [branch, setBranch] = useState("main");
+  const [githubUrl, setGithubUrl] = useState("");
+  const [branch, setBranch] = useState("main");
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleConfirmAction = useCallback(async () => {
-    await onConfirm(githubUrl, branch);
-    setOpen(false);
-  }, [onConfirm, githubUrl, branch]);
+  const resetForm = useCallback(() => {
+    setGithubUrl("");
+    setBranch("main");
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (isSubmitting) {
+        return;
+      }
+      const trimmedUrl = githubUrl.trim();
+      const trimmedBranch = branch.trim();
+      if (!trimmedUrl || !trimmedBranch) {
+        return;
+      }
+      setIsSubmitting(true);
+      try {
+        await onConfirm(trimmedUrl, trimmedBranch);
+        resetForm();
+        setOpen(false);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [branch, githubUrl, isSubmitting, onConfirm, resetForm],
+  );
 
   const handleCancel = useCallback(async () => {
-    if (!onCancel) {
-      setOpen(false);
+    if (isSubmitting) {
       return;
     }
-    await onCancel();
+    if (onCancel) {
+      await onCancel();
+    }
+    resetForm();
     setOpen(false);
-  }, [onCancel]);
+  }, [isSubmitting, onCancel, resetForm]);
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          resetForm();
+          setIsSubmitting(false);
+        }
+        setOpen(nextOpen);
+      }}
+    >
       <DialogTrigger asChild>
         <Button variant="outline">{buttonText}</Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle>Select Github Repo</DialogTitle>
-					{/* <DialogDescription></DialogDescription> */}
+          {/* <DialogDescription></DialogDescription> */}
         </DialogHeader>
-					<div>
-					  <label>
-							Github Url
-							<Input
-								name="githubUrl"
-								value={githubUrl}
-								onChange={(e)=>setGithubUrl(e.target.value)}
-								type="text"
-								placeholder="https://github.com/timonteutelink/example-templates"
-							/>
-						</label>
-					  <label>
-							Branch
-							<Input
-								name="branch"
-								value={branch}
-								onChange={(e)=>setBranch(e.target.value)}
-								type="text"
-								placeholder="main"
-							/>
-						</label>
-				  
-					</div>
-        <DialogFooter className="mt-4">
-          <Button variant="outline" onClick={handleCancel}>
-            Cancel
-          </Button>
-          <Button
-            variant="default"
-            onClick={handleConfirmAction}
-            className="ml-2"
-          >
-					  {actionText}
-          </Button>
-        </DialogFooter>
+        <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="github-url">GitHub URL</Label>
+            <Input
+              id="github-url"
+              name="githubUrl"
+              value={githubUrl}
+              onChange={(e) => setGithubUrl(e.target.value)}
+              type="url"
+              placeholder="https://github.com/timonteutelink/example-templates"
+              autoFocus
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="github-branch">Branch</Label>
+            <Input
+              id="github-branch"
+              name="branch"
+              value={branch}
+              onChange={(e) => setBranch(e.target.value)}
+              type="text"
+              placeholder="main"
+              required
+            />
+          </div>
+          <DialogFooter className="mt-4">
+            <Button
+              variant="outline"
+              onClick={handleCancel}
+              type="button"
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="default"
+              type="submit"
+              className="ml-2"
+              disabled={
+                isSubmitting || !githubUrl.trim() || !branch.trim()
+              }
+            >
+              {actionText}
+            </Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary
- simplify the confirmation dialog form submission so the destructive action is disabled while a request is pending
- wrap the git repository selection and commit dialogs in minimal forms that reset their state on close and prevent duplicate submissions
- refresh the template page repo loader to call the dialog handler and reload templates after a successful import, and tidy the file upload dialog cancellation flow

## Testing
- pnpm lint --filter web *(fails: Unsupported package manager specification (bun@1.2.12))*

------
https://chatgpt.com/codex/tasks/task_e_68ca788ca5588325985593e47d88872e