### PR TITLE
Require commit hash for template config caching and centralize rollback

### DIFF
--- a/packages/skaff-lib/src/models/project.ts
+++ b/packages/skaff-lib/src/models/project.ts
@@ -89,14 +89,37 @@ export class Project {
       parentFinalSettings = newInstantiatedSettings.data;
     }
 
-    const finalSettings = template.config.mapFinalSettings({
-      fullProjectSettings: projectSettings,
-      templateSettings: parsedUserSettings.data,
-      parentSettings: parentFinalSettings,
-      aiResults: {},
-    });
+    const templateName = template.config.templateConfig.name;
+    let mappedSettings: FinalTemplateSettings;
+    try {
+      mappedSettings = template.config.mapFinalSettings({
+        fullProjectSettings: projectSettings,
+        templateSettings: parsedUserSettings.data,
+        parentSettings: parentFinalSettings,
+        aiResults: {},
+      });
+    } catch (error) {
+      logError({
+        shortMessage: `Failed to map final settings for template ${templateName}`,
+        error,
+      });
+      return {
+        error: `Failed to map final settings for template ${templateName}: ${error}`,
+      };
+    }
 
-    return { data: finalSettings };
+    const parsedFinalSettings =
+      template.config.templateFinalSettingsSchema.safeParse(mappedSettings);
+    if (!parsedFinalSettings.success) {
+      backendLogger.error(
+        `Invalid final template settings for template ${templateName}: ${parsedFinalSettings.error}`,
+      );
+      return {
+        error: `Invalid final template settings for template ${templateName}: ${parsedFinalSettings.error}`,
+      };
+    }
+
+    return { data: parsedFinalSettings.data };
   }
 
   /**
@@ -149,14 +172,37 @@ export class Project {
       parentSettings = finalParentSettings.data;
     }
 
-    const finalSettings = template.config.mapFinalSettings({
-      fullProjectSettings: instantiatedProjectSettings,
-      templateSettings: parsedUserProvidedSettingsSchema.data,
-      parentSettings: parentSettings,
-      aiResults: {},
-    });
+    const templateName = template.config.templateConfig.name;
+    let mappedSettings: FinalTemplateSettings;
+    try {
+      mappedSettings = template.config.mapFinalSettings({
+        fullProjectSettings: instantiatedProjectSettings,
+        templateSettings: parsedUserProvidedSettingsSchema.data,
+        parentSettings: parentSettings,
+        aiResults: {},
+      });
+    } catch (error) {
+      logError({
+        shortMessage: `Failed to map final settings for template ${templateName}`,
+        error,
+      });
+      return {
+        error: `Failed to map final settings for template ${templateName}: ${error}`,
+      };
+    }
 
-    return { data: finalSettings };
+    const parsedFinalSettings =
+      template.config.templateFinalSettingsSchema.safeParse(mappedSettings);
+    if (!parsedFinalSettings.success) {
+      backendLogger.error(
+        `Invalid final template settings for template ${templateName}: ${parsedFinalSettings.error}`,
+      );
+      return {
+        error: `Invalid final template settings for template ${templateName}: ${parsedFinalSettings.error}`,
+      };
+    }
+
+    return { data: parsedFinalSettings.data };
   }
 
   static async create(absDir: string): Promise<Result<Project>> {

--- a/packages/skaff-lib/src/models/template.ts
+++ b/packages/skaff-lib/src/models/template.ts
@@ -201,7 +201,10 @@ export class Template {
 
     let configs: Record<string, TemplateConfigWithFileInfo>;
     try {
-      configs = await loadAllTemplateConfigs(absoluteRootDir);
+      configs = await loadAllTemplateConfigs(
+        absoluteRootDir,
+        commitHash.data,
+      );
     } catch (error) {
       logError({
         error,

--- a/packages/skaff-lib/src/services/file-rollback-service.ts
+++ b/packages/skaff-lib/src/services/file-rollback-service.ts
@@ -1,0 +1,137 @@
+import fs from "fs-extra";
+import path from "node:path";
+
+import { backendLogger } from "../lib/logger";
+import { Result } from "../lib/types";
+
+interface FileSnapshot {
+  existed: boolean;
+  content?: Buffer;
+  mode?: number;
+}
+
+export class FileRollbackManager {
+  private readonly fileSnapshots = new Map<string, FileSnapshot>();
+  private readonly createdDirectories = new Set<string>();
+
+  public async ensureDir(dirPath: string): Promise<Result<void>> {
+    const resolved = path.resolve(dirPath);
+    const dirsToCreate: string[] = [];
+    let current = resolved;
+
+    while (true) {
+      try {
+        const stat = await fs.stat(current);
+        if (!stat.isDirectory()) {
+          return {
+            error: `Path ${current} exists and is not a directory`,
+          };
+        }
+        break;
+      } catch (error) {
+        const err = error as NodeJS.ErrnoException;
+        if (err.code === "ENOENT") {
+          dirsToCreate.push(current);
+          const parent = path.dirname(current);
+          if (parent === current) {
+            break;
+          }
+          current = parent;
+          continue;
+        }
+        return {
+          error: `Failed to inspect directory ${current}: ${error}`,
+        };
+      }
+    }
+
+    try {
+      await fs.ensureDir(resolved);
+    } catch (error) {
+      return {
+        error: `Failed to ensure directory ${resolved}: ${error}`,
+      };
+    }
+
+    dirsToCreate.forEach((dir) => this.createdDirectories.add(dir));
+
+    return { data: undefined };
+  }
+
+  public async trackFile(filePath: string): Promise<Result<void>> {
+    const resolved = path.resolve(filePath);
+    if (this.fileSnapshots.has(resolved)) {
+      return { data: undefined };
+    }
+
+    try {
+      const stat = await fs.stat(resolved);
+      if (!stat.isFile()) {
+        return {
+          error: `Path ${resolved} exists and is not a file`,
+        };
+      }
+      const contents = await fs.readFile(resolved);
+      this.fileSnapshots.set(resolved, {
+        existed: true,
+        content: contents,
+        mode: stat.mode,
+      });
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code === "ENOENT") {
+        this.fileSnapshots.set(resolved, { existed: false });
+      } else {
+        return {
+          error: `Failed to inspect file ${resolved}: ${error}`,
+        };
+      }
+    }
+
+    return { data: undefined };
+  }
+
+  public async rollback(): Promise<void> {
+    const files = Array.from(this.fileSnapshots.entries()).reverse();
+    for (const [filePath, snapshot] of files) {
+      try {
+        if (!snapshot.existed) {
+          await fs.remove(filePath);
+        } else if (snapshot.content !== undefined) {
+          await fs.ensureDir(path.dirname(filePath));
+          await fs.writeFile(filePath, snapshot.content);
+          if (typeof snapshot.mode === "number") {
+            await fs.chmod(filePath, snapshot.mode);
+          }
+        }
+      } catch (error) {
+        backendLogger.error(`Failed to rollback file ${filePath}`, error);
+      }
+    }
+
+    const dirs = Array.from(this.createdDirectories).sort(
+      (a, b) => b.length - a.length,
+    );
+    for (const dir of dirs) {
+      try {
+        const exists = await fs.pathExists(dir);
+        if (!exists) {
+          continue;
+        }
+        const entries = await fs.readdir(dir);
+        if (entries.length === 0) {
+          await fs.rmdir(dir);
+        }
+      } catch (error) {
+        backendLogger.error(`Failed to rollback directory ${dir}`, error);
+      }
+    }
+
+    this.clear();
+  }
+
+  public clear(): void {
+    this.fileSnapshots.clear();
+    this.createdDirectories.clear();
+  }
+}


### PR DESCRIPTION
## Summary
- require a commit hash when loading template configs and base the cache key on the hash plus the template root path
- move the file rollback logic into a dedicated service and hook it into new project instantiation and failure handling
- keep template instantiation resilient by rolling back tracked filesystem mutations on errors

## Testing
- bun run --cwd packages/skaff-lib check-types

------
https://chatgpt.com/codex/tasks/task_e_68cc4ceddd608325b348b58a30bf8386