### PR TITLE
Add Google site verification tag to docs head

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -99,6 +99,9 @@ module.exports = {
   ],
 
   themeConfig: {
+    metadata: [
+      { name: 'google-site-verification', content: 'yHZDx1a_TvuAyo3wPFQyqJpnYHDAMzendF881Vejwyo' }
+    ],
     navbar: {
       logo: { src: 'img/logo.svg', alt: 'logo' },
       items: [


### PR DESCRIPTION
## Summary
- add the Google site verification meta tag to the docs site's head metadata

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5b90c59ac8325a1c67bff129cda49