### PR TITLE
Refactor project creation flow

### DIFF
--- a/packages/skaff-lib/src/actions/instantiate/generate-new-project-from-existing.ts
+++ b/packages/skaff-lib/src/actions/instantiate/generate-new-project-from-existing.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { ProjectCreationOptions, ProjectCreationResult, Result } from "../../lib";
 import { Project } from "../../models";
-import { generateProjectFromTemplateSettings } from "../../services/project-service";
+import { generateProjectFromTemplateSettings } from "../../core/projects/ProjectCreationFacade";
 
 export async function generateNewProjectFromExisting(
   oldProject: Project,

--- a/packages/skaff-lib/src/actions/instantiate/generate-new-project-from-settings.ts
+++ b/packages/skaff-lib/src/actions/instantiate/generate-new-project-from-settings.ts
@@ -5,7 +5,7 @@ import {
   ProjectCreationOptions
 } from "../../lib";
 import { logError } from "../../lib/utils";
-import { generateProjectFromTemplateSettings } from "../../services/project-service";
+import { generateProjectFromTemplateSettings } from "../../core/projects/ProjectCreationFacade";
 import { ProjectSettings, projectSettingsSchema } from "@timonteutelink/template-types-lib";
 
 export async function generateNewProjectFromSettings(

--- a/packages/skaff-lib/src/actions/instantiate/generate-new-project.ts
+++ b/packages/skaff-lib/src/actions/instantiate/generate-new-project.ts
@@ -1,6 +1,6 @@
 import { UserTemplateSettings } from "@timonteutelink/template-types-lib";
 import { ProjectCreationOptions, ProjectCreationResult, Result } from "../../lib";
-import { instantiateProject } from "../../services/project-service";
+import { instantiateProject } from "../../core/projects/ProjectCreationFacade";
 
 export async function generateNewProject(
   projectName: string,

--- a/packages/skaff-lib/src/core/diffing/TemporaryProjectFactory.ts
+++ b/packages/skaff-lib/src/core/diffing/TemporaryProjectFactory.ts
@@ -4,7 +4,7 @@ import { ProjectSettings } from "@timonteutelink/template-types-lib";
 
 import { Result } from "../../lib/types";
 import { Project } from "../../models/project";
-import { ProjectLifecycle } from "../projects/ProjectLifecycle";
+import { ProjectCreationManager } from "../projects/ProjectCreationManager";
 import { DiffCache } from "./DiffCache";
 
 interface TemporaryProject {
@@ -13,7 +13,7 @@ interface TemporaryProject {
 }
 
 export class TemporaryProjectFactory {
-  private readonly lifecycle = new ProjectLifecycle({ git: false });
+  private readonly manager = new ProjectCreationManager({ git: false });
 
   constructor(private readonly cache = new DiffCache()) {}
 
@@ -30,7 +30,7 @@ export class TemporaryProjectFactory {
       await fs.rm(tempPathResult.data, { recursive: true, force: true });
     };
 
-    const generationResult = await this.lifecycle.generateFromTemplateSettings(
+    const generationResult = await this.manager.generateFromTemplateSettings(
       projectSettings,
       tempPathResult.data,
     );
@@ -61,7 +61,7 @@ export class TemporaryProjectFactory {
       await fs.rm(tempPathResult.data, { recursive: true, force: true });
     };
 
-    const generationResult = await this.lifecycle.generateFromExistingProject(
+    const generationResult = await this.manager.generateFromExistingProject(
       project,
       tempPathResult.data,
     );

--- a/packages/skaff-lib/src/core/projects/ProjectCreationFacade.ts
+++ b/packages/skaff-lib/src/core/projects/ProjectCreationFacade.ts
@@ -2,20 +2,22 @@ import {
   ProjectSettings,
   UserTemplateSettings,
 } from "@timonteutelink/template-types-lib";
+
 import {
   ProjectCreationOptions,
   ProjectCreationResult,
   Result,
-} from "../lib/types";
-import { Project } from "../models/project";
-import { ProjectLifecycle } from "../core/projects/ProjectLifecycle";
+} from "../../lib/types";
+import { Project } from "../../models/project";
+
+import { ProjectCreationManager } from "./ProjectCreationManager";
 
 export async function parseProjectCreationResult(
   projectPath: string,
   projectCreationOptions?: ProjectCreationOptions,
 ): Promise<Result<ProjectCreationResult>> {
-  const lifecycle = new ProjectLifecycle(projectCreationOptions);
-  return lifecycle.parseCreationResult(projectPath);
+  const manager = new ProjectCreationManager(projectCreationOptions);
+  return manager.parseCreationResult(projectPath);
 }
 
 export async function instantiateProject(
@@ -25,8 +27,8 @@ export async function instantiateProject(
   userTemplateSettings: UserTemplateSettings,
   projectCreationOptions?: ProjectCreationOptions,
 ): Promise<Result<ProjectCreationResult>> {
-  const lifecycle = new ProjectLifecycle(projectCreationOptions);
-  return lifecycle.instantiateProject(
+  const manager = new ProjectCreationManager(projectCreationOptions);
+  return manager.instantiateProject(
     rootTemplateName,
     parentDirPath,
     newProjectName,
@@ -37,10 +39,10 @@ export async function instantiateProject(
 export async function generateProjectFromExistingProject(
   existingProject: Project,
   newProjectPath: string,
-  ProjectCreationOptions?: ProjectCreationOptions,
+  projectCreationOptions?: ProjectCreationOptions,
 ): Promise<Result<ProjectCreationResult>> {
-  const lifecycle = new ProjectLifecycle(ProjectCreationOptions);
-  return lifecycle.generateFromExistingProject(existingProject, newProjectPath);
+  const manager = new ProjectCreationManager(projectCreationOptions);
+  return manager.generateFromExistingProject(existingProject, newProjectPath);
 }
 
 /**
@@ -51,6 +53,6 @@ export async function generateProjectFromTemplateSettings(
   newProjectPath: string,
   projectCreationOptions?: ProjectCreationOptions,
 ): Promise<Result<ProjectCreationResult>> {
-  const lifecycle = new ProjectLifecycle(projectCreationOptions);
-  return lifecycle.generateFromTemplateSettings(projectSettings, newProjectPath);
+  const manager = new ProjectCreationManager(projectCreationOptions);
+  return manager.generateFromTemplateSettings(projectSettings, newProjectPath);
 }

--- a/packages/skaff-lib/src/core/projects/ProjectCreationManager.ts
+++ b/packages/skaff-lib/src/core/projects/ProjectCreationManager.ts
@@ -22,10 +22,8 @@ import {
 } from "../../services/git-service";
 import { TemplateGeneratorService } from "../../services/template-generator-service";
 
-export class ProjectLifecycle {
-  constructor(
-    private readonly options?: ProjectCreationOptions,
-  ) {}
+export class ProjectCreationManager {
+  constructor(private readonly options?: ProjectCreationOptions) {}
 
   public async parseCreationResult(
     projectPath: string,

--- a/packages/skaff-lib/src/core/templates/Template.ts
+++ b/packages/skaff-lib/src/core/templates/Template.ts
@@ -18,7 +18,7 @@ import { backendLogger } from "../../lib/logger";
 import { logError } from "../../lib/utils";
 import { TemplateGeneratorService } from "../../services/template-generator-service";
 import { Project } from "../../models/project";
-import { parseProjectCreationResult } from "../../services/project-service";
+import { parseProjectCreationResult } from "../projects/ProjectCreationFacade";
 import { getCacheDirPath } from "../../services/cache-service";
 import {
   getCommitHash,


### PR DESCRIPTION
## Summary
- rename ProjectLifecycle to ProjectCreationManager and expose helper facade inside core
- move project-service APIs into new ProjectCreationFacade that uses the manager
- update template, diff factory, and instantiate actions to consume the new facade

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d5c3bbaae48325b48a5c4ffe8efef5