### PR TITLE
refactor: reorganize template migration and config loader

### DIFF
--- a/packages/skaff-lib/src/core/diffing/AutoInstantiationSettingsAdjuster.ts
+++ b/packages/skaff-lib/src/core/diffing/AutoInstantiationSettingsAdjuster.ts
@@ -12,7 +12,7 @@ import { anyOrCallbackToAny } from "../../lib/utils";
 import { Project } from "../../models/project";
 import { Template } from "../../models/template";
 import { getRootTemplateRepository } from "../../repositories";
-import { latestMigrationUuid } from "../../services/template-migration-service";
+import { getLatestTemplateMigrationUuid } from "../templates/TemplateMigration";
 
 export class AutoInstantiationSettingsAdjuster {
   public async modifyAutoInstantiatedTemplates(
@@ -300,7 +300,9 @@ export class AutoInstantiationSettingsAdjuster {
         };
       }
 
-      const lastMigration = latestMigrationUuid(subTemplate.config.migrations);
+      const lastMigration = getLatestTemplateMigrationUuid(
+        subTemplate.config.migrations,
+      );
 
       projectSettings.instantiatedTemplates.push({
         id: autoInstantiatedTemplateInstanceId,

--- a/packages/skaff-lib/src/core/diffing/MigrationApplier.ts
+++ b/packages/skaff-lib/src/core/diffing/MigrationApplier.ts
@@ -4,9 +4,9 @@ import {
 } from "@timonteutelink/template-types-lib";
 
 import {
-  applyTemplateMigrations,
-  latestMigrationUuid,
-} from "../../services/template-migration-service";
+  applyTemplateMigrationSequence,
+  getLatestTemplateMigrationUuid,
+} from "../templates/TemplateMigration";
 
 export class MigrationApplier {
   public applyMigrations(
@@ -14,12 +14,12 @@ export class MigrationApplier {
     settings: UserTemplateSettings,
     fromMigration?: string,
   ): { settings: UserTemplateSettings; lastMigration?: string } {
-    return applyTemplateMigrations(migrations, settings, fromMigration);
+    return applyTemplateMigrationSequence(migrations, settings, fromMigration);
   }
 
   public getLatestMigration(
     migrations: TemplateMigration[] | undefined,
   ): string | undefined {
-    return latestMigrationUuid(migrations);
+    return getLatestTemplateMigrationUuid(migrations);
   }
 }

--- a/packages/skaff-lib/src/core/generation/ProjectSettingsSynchronizer.ts
+++ b/packages/skaff-lib/src/core/generation/ProjectSettingsSynchronizer.ts
@@ -13,7 +13,7 @@ import {
   writeNewProjectSettings,
   writeNewTemplateToSettings,
 } from "../../services/project-settings-service";
-import { latestMigrationUuid } from "../../services/template-migration-service";
+import { getLatestTemplateMigrationUuid } from "../templates/TemplateMigration";
 import { GeneratorOptions } from "../../services/template-generator-service";
 
 export class ProjectSettingsSynchronizer {
@@ -110,7 +110,7 @@ export class ProjectSettingsSynchronizer {
     }
 
     const newProjectId = newUuid || crypto.randomUUID();
-    const lastMigration = latestMigrationUuid(
+    const lastMigration = getLatestTemplateMigrationUuid(
       this.rootTemplate.config.migrations,
     );
 
@@ -183,7 +183,9 @@ export class ProjectSettingsSynchronizer {
     }
 
     const newProjectId = newUuid || crypto.randomUUID();
-    const lastMigration = latestMigrationUuid(template.config.migrations);
+    const lastMigration = getLatestTemplateMigrationUuid(
+      template.config.migrations,
+    );
 
     this.destinationProjectSettings.instantiatedTemplates.push({
       id: newProjectId,

--- a/packages/skaff-lib/src/core/templates/TemplateMigration.ts
+++ b/packages/skaff-lib/src/core/templates/TemplateMigration.ts
@@ -1,6 +1,6 @@
 import { TemplateMigration, UserTemplateSettings } from "@timonteutelink/template-types-lib";
 
-export function applyTemplateMigrations(
+export function applyTemplateMigrationSequence(
   migrations: TemplateMigration[] | undefined,
   settings: UserTemplateSettings,
   fromMigration?: string,
@@ -24,7 +24,7 @@ export function applyTemplateMigrations(
   return { settings: currentSettings, lastMigration: currentId };
 }
 
-export function latestMigrationUuid(
+export function getLatestTemplateMigrationUuid(
   migrations: TemplateMigration[] | undefined,
 ): string | undefined {
   if (!migrations || migrations.length === 0) {

--- a/packages/skaff-lib/src/core/templates/TemplateTreeBuilder.ts
+++ b/packages/skaff-lib/src/core/templates/TemplateTreeBuilder.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import {
   loadAllTemplateConfigs,
   TemplateConfigWithFileInfo,
-} from "../../loaders/template-config-loader";
+} from "./config/TemplateConfigLoader";
 import { backendLogger } from "../../lib/logger";
 import { Result } from "../../lib/types";
 import { logError } from "../../lib/utils";

--- a/packages/skaff-lib/src/core/templates/config/TemplateConfigLoader.ts
+++ b/packages/skaff-lib/src/core/templates/config/TemplateConfigLoader.ts
@@ -12,10 +12,10 @@ import {
   getHash,
   retrieveFromCache,
   saveToCache,
-} from "../services/cache-service";
-import { initEsbuild } from "../utils/get-esbuild";
+} from "../../../services/cache-service";
+import { initEsbuild } from "../../../utils/get-esbuild";
 import { existsSync } from "node:fs";
-import { GenericTemplateConfigModule } from "../lib";
+import { GenericTemplateConfigModule } from "../../../lib";
 
 const { templateConfigSchema } = templateTypesLibNS;
 

--- a/packages/skaff-lib/src/core/templates/index.ts
+++ b/packages/skaff-lib/src/core/templates/index.ts
@@ -9,3 +9,7 @@ export {
 } from "./TemplateValidation";
 export { TemplateTreeBuilder } from "./TemplateTreeBuilder";
 export type { TemplateTreeBuilderOptions } from "./TemplateTreeBuilder";
+export {
+  applyTemplateMigrationSequence,
+  getLatestTemplateMigrationUuid,
+} from "./TemplateMigration";


### PR DESCRIPTION
## Summary
- relocate template migration helpers into the core templates module and rename them to clearer apply/get helpers
- move the template config loader under core/templates/config and fix dependent imports
- re-export the new helpers so downstream consumers and actions resolve the new classnames

## Testing
- bun run lint *(fails: existing lint warnings about any/ts-ignore)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c89ef0108325aaf0c7cd1417d88e