### PR TITLE
refactor: reorganize services into core modules

### DIFF
--- a/packages/skaff-lib/src/actions/git/add-all-and-commit.ts
+++ b/packages/skaff-lib/src/actions/git/add-all-and-commit.ts
@@ -1,7 +1,7 @@
 import { Result } from "../../lib";
 import { logError } from "../../lib/utils";
 import { Project } from "../../models";
-import { commitAll } from "../../services/git-service";
+import { commitAll } from "../../core/infra/git-service";
 
 /**
  * @public

--- a/packages/skaff-lib/src/actions/git/diff-project-from-template.ts
+++ b/packages/skaff-lib/src/actions/git/diff-project-from-template.ts
@@ -1,6 +1,6 @@
 import { ParsedFile, Result } from "../../lib";
 import { Project } from "../../models";
-import { diffProjectFromItsTemplate } from "../../services/project-diff-service";
+import { diffProjectFromItsTemplate } from "../../core/diffing/project-diff-service";
 
 export async function diffProjectFromTemplate(
   project: Project

--- a/packages/skaff-lib/src/actions/git/switch-project-branch.ts
+++ b/packages/skaff-lib/src/actions/git/switch-project-branch.ts
@@ -1,7 +1,7 @@
 import { Result } from "../../lib";
 import { logError } from "../../lib/utils";
 import { Project } from "../../models";
-import { switchBranch } from "../../services/git-service";
+import { switchBranch } from "../../core/infra/git-service";
 
 export async function switchProjectBranch(
   project: Project,

--- a/packages/skaff-lib/src/actions/instantiate/add-all-and-diff.ts
+++ b/packages/skaff-lib/src/actions/instantiate/add-all-and-diff.ts
@@ -3,7 +3,7 @@ import { Project } from "../../models";
 import {
   addAllAndRetrieveDiff,
   parseGitDiff,
-} from "../../services/git-service";
+} from "../../core/infra/git-service";
 
 export async function addAllAndDiff(
   project: Project

--- a/packages/skaff-lib/src/actions/instantiate/apply-diff.ts
+++ b/packages/skaff-lib/src/actions/instantiate/apply-diff.ts
@@ -1,6 +1,6 @@
 import { ParsedFile, Result } from "../../lib";
 import { Project } from "../../models";
-import { applyDiffToProject } from "../../services/project-diff-service";
+import { applyDiffToProject } from "../../core/diffing/project-diff-service";
 
 export async function applyDiff(
   project: Project,

--- a/packages/skaff-lib/src/actions/instantiate/delete-project.ts
+++ b/packages/skaff-lib/src/actions/instantiate/delete-project.ts
@@ -1,6 +1,6 @@
 import { Result } from "../../lib";
 import { Project } from "../../models";
-import { deleteRepo } from "../../services/git-service";
+import { deleteRepo } from "../../core/infra/git-service";
 
 export async function deleteProject(
   project: Project,

--- a/packages/skaff-lib/src/actions/instantiate/prepare-instantiation-diff.ts
+++ b/packages/skaff-lib/src/actions/instantiate/prepare-instantiation-diff.ts
@@ -1,7 +1,7 @@
 import { UserTemplateSettings } from "@timonteutelink/template-types-lib";
 import { NewTemplateDiffResult, Result } from "../../lib";
 import { Project } from "../../models";
-import { generateNewTemplateDiff } from "../../services/project-diff-service";
+import { generateNewTemplateDiff } from "../../core/diffing/project-diff-service";
 
 export async function prepareInstantiationDiff(
   rootTemplateName: string,

--- a/packages/skaff-lib/src/actions/instantiate/prepare-modification-diff.ts
+++ b/packages/skaff-lib/src/actions/instantiate/prepare-modification-diff.ts
@@ -1,6 +1,6 @@
 import { UserTemplateSettings } from "@timonteutelink/template-types-lib";
 import { NewTemplateDiffResult, Result } from "../../lib";
-import { generateModifyTemplateDiff } from "../../services/project-diff-service";
+import { generateModifyTemplateDiff } from "../../core/diffing/project-diff-service";
 import { Project } from "../../models";
 
 export async function prepareModificationDiff(

--- a/packages/skaff-lib/src/actions/instantiate/prepare-update-diff.ts
+++ b/packages/skaff-lib/src/actions/instantiate/prepare-update-diff.ts
@@ -1,6 +1,6 @@
 import { NewTemplateDiffResult, Result } from "../../lib";
 import { Project } from "../../models";
-import { generateUpdateTemplateDiff } from "../../services/project-diff-service";
+import { generateUpdateTemplateDiff } from "../../core/diffing/project-diff-service";
 
 export async function prepareUpdateDiff(
   project: Project,

--- a/packages/skaff-lib/src/actions/instantiate/restore-all-changes.ts
+++ b/packages/skaff-lib/src/actions/instantiate/restore-all-changes.ts
@@ -1,6 +1,6 @@
 import { Result } from "../../lib";
 import { Project } from "../../models";
-import { resetAllChanges } from "../../services/git-service";
+import { resetAllChanges } from "../../core/infra/git-service";
 
 export async function restoreAllChanges(
   project: Project

--- a/packages/skaff-lib/src/actions/template/erase-cache.ts
+++ b/packages/skaff-lib/src/actions/template/erase-cache.ts
@@ -1,7 +1,7 @@
 import { Result } from "../../lib";
 import { Template } from "../../models";
 import { getRootTemplateRepository } from "../../repositories";
-import { runEraseCache } from "../../services/cache-service";
+import { runEraseCache } from "../../core/infra/cache-service";
 import { getTemplates } from "./get-templates";
 
 export async function eraseCache(): Promise<Result<{

--- a/packages/skaff-lib/src/core/diffing/DiffCache.ts
+++ b/packages/skaff-lib/src/core/diffing/DiffCache.ts
@@ -7,7 +7,7 @@ import {
   pathInCache,
   retrieveFromCache,
   saveToCache,
-} from "../../services/cache-service";
+} from "../infra/cache-service";
 
 export class DiffCache {
   public computeSettingsHash(settings: ProjectSettings): string {

--- a/packages/skaff-lib/src/core/diffing/ProjectDiffPlanner.ts
+++ b/packages/skaff-lib/src/core/diffing/ProjectDiffPlanner.ts
@@ -16,7 +16,7 @@ import {
   diffDirectories,
   isConflictAfterApply,
   parseGitDiff,
-} from "../../services/git-service";
+} from "../infra/git-service";
 import { MigrationApplier } from "./MigrationApplier";
 import { DiffCache } from "./DiffCache";
 import { AutoInstantiationSettingsAdjuster } from "./AutoInstantiationSettingsAdjuster";

--- a/packages/skaff-lib/src/core/diffing/project-diff-service.ts
+++ b/packages/skaff-lib/src/core/diffing/project-diff-service.ts
@@ -1,8 +1,8 @@
 import { UserTemplateSettings } from "@timonteutelink/template-types-lib";
 
-import { NewTemplateDiffResult, ParsedFile, Result } from "../lib/types";
-import { Project } from "../models/project";
-import { ProjectDiffPlanner } from "../core/diffing/ProjectDiffPlanner";
+import { NewTemplateDiffResult, ParsedFile, Result } from "../../lib/types";
+import { Project } from "../../models/project";
+import { ProjectDiffPlanner } from "./ProjectDiffPlanner";
 
 const planner = new ProjectDiffPlanner();
 

--- a/packages/skaff-lib/src/core/generation/AutoInstantiationPlanner.ts
+++ b/packages/skaff-lib/src/core/generation/AutoInstantiationPlanner.ts
@@ -6,7 +6,7 @@ import {
 import { backendLogger } from "../../lib/logger";
 import { Result } from "../../lib/types";
 import { anyOrCallbackToAny } from "../../lib/utils";
-import { GeneratorOptions } from "../../services/template-generator-service";
+import { GeneratorOptions } from "./template-generator-service";
 import { GenerationContext } from "./GenerationContext";
 import { ProjectSettingsSynchronizer } from "./ProjectSettingsSynchronizer";
 

--- a/packages/skaff-lib/src/core/generation/GitWorkflow.ts
+++ b/packages/skaff-lib/src/core/generation/GitWorkflow.ts
@@ -1,5 +1,5 @@
 import { Result } from "../../lib/types";
-import { commitAll, createGitRepo } from "../../services/git-service";
+import { commitAll, createGitRepo } from "../infra/git-service";
 
 export class GitWorkflow {
   public async initializeRepository(projectPath: string): Promise<Result<void>> {

--- a/packages/skaff-lib/src/core/generation/ProjectSettingsSynchronizer.ts
+++ b/packages/skaff-lib/src/core/generation/ProjectSettingsSynchronizer.ts
@@ -12,9 +12,9 @@ import {
   removeTemplateFromSettings,
   writeNewProjectSettings,
   writeNewTemplateToSettings,
-} from "../../services/project-settings-service";
+} from "../projects/project-settings-service";
 import { getLatestTemplateMigrationUuid } from "../templates/TemplateMigration";
-import { GeneratorOptions } from "../../services/template-generator-service";
+import { GeneratorOptions } from "./template-generator-service";
 
 export class ProjectSettingsSynchronizer {
   constructor(

--- a/packages/skaff-lib/src/core/generation/template-generator-service.ts
+++ b/packages/skaff-lib/src/core/generation/template-generator-service.ts
@@ -3,22 +3,22 @@ import {
   UserTemplateSettings,
 } from "@timonteutelink/template-types-lib";
 import fs from "fs-extra";
-import { backendLogger } from "../lib/logger";
-import { Result } from "../lib/types";
-import { anyOrCallbackToAny, logError } from "../lib/utils";
-import { AutoInstantiationPlanner } from "../core/generation/AutoInstantiationPlanner";
-import { FileMaterializer } from "../core/generation/FileMaterializer";
-import { GenerationContext } from "../core/generation/GenerationContext";
-import { GitWorkflow } from "../core/generation/GitWorkflow";
-import { PathResolver } from "../core/generation/PathResolver";
-import { ProjectSettingsSynchronizer } from "../core/generation/ProjectSettingsSynchronizer";
-import { RollbackFileSystem } from "../core/generation/RollbackFileSystem";
-import { SideEffectExecutor } from "../core/generation/SideEffectExecutor";
-import { HandlebarsEnvironment } from "../core/shared/HandlebarsEnvironment";
-import { Template } from "../models/template";
-import { isSubset } from "../utils/shared-utils";
-import { makeDir } from "./file-service";
-import { FileRollbackManager } from "../core/shared/FileRollbackManager";
+import { backendLogger } from "../../lib/logger";
+import { Result } from "../../lib/types";
+import { anyOrCallbackToAny, logError } from "../../lib/utils";
+import { AutoInstantiationPlanner } from "./AutoInstantiationPlanner";
+import { FileMaterializer } from "./FileMaterializer";
+import { GenerationContext } from "./GenerationContext";
+import { GitWorkflow } from "./GitWorkflow";
+import { PathResolver } from "./PathResolver";
+import { ProjectSettingsSynchronizer } from "./ProjectSettingsSynchronizer";
+import { RollbackFileSystem } from "./RollbackFileSystem";
+import { SideEffectExecutor } from "./SideEffectExecutor";
+import { HandlebarsEnvironment } from "../shared/HandlebarsEnvironment";
+import { Template } from "../../models/template";
+import { isSubset } from "../../utils/shared-utils";
+import { makeDir } from "../infra/file-service";
+import { FileRollbackManager } from "../shared/FileRollbackManager";
 
 export interface GeneratorOptions {
   /**

--- a/packages/skaff-lib/src/core/infra/cache-service.ts
+++ b/packages/skaff-lib/src/core/infra/cache-service.ts
@@ -2,10 +2,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import * as fs from "node:fs/promises";
 import { makeDir } from "./file-service";
-import { Result } from "../lib/types";
+import { Result } from "../../lib/types";
 import { createHash } from "node:crypto";
-import { backendLogger } from "../lib/logger";
-import { logError } from "../lib/utils";
+import { backendLogger } from "../../lib/logger";
+import { logError } from "../../lib/utils";
 
 export type CacheKey =
   | "template-config"

--- a/packages/skaff-lib/src/core/infra/file-rollback-service.ts
+++ b/packages/skaff-lib/src/core/infra/file-rollback-service.ts
@@ -1,0 +1,1 @@
+export { FileRollbackManager } from "../shared/FileRollbackManager";

--- a/packages/skaff-lib/src/core/infra/file-service.ts
+++ b/packages/skaff-lib/src/core/infra/file-service.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
-import { Result } from "../lib/types";
-import { backendLogger } from "../lib/logger";
+import { Result } from "../../lib/types";
+import { backendLogger } from "../../lib/logger";
 
 export async function makeDir(path: string): Promise<Result<void>> {
   try {

--- a/packages/skaff-lib/src/core/infra/git-service.ts
+++ b/packages/skaff-lib/src/core/infra/git-service.ts
@@ -5,9 +5,9 @@ import path from "node:path";
 import fsExtra from "fs-extra";
 import simpleGit from "simple-git";
 
-import { DiffHunk, GitStatus, ParsedFile, Result } from "../lib/types";
-import { logError } from "../lib/utils";
-import type { Template } from "../core/templates";
+import { DiffHunk, GitStatus, ParsedFile, Result } from "../../lib/types";
+import { logError } from "../../lib/utils";
+import type { Template } from "../templates";
 import { pathInCache } from "./cache-service";
 import { npmInstall } from "./npm-service";
 

--- a/packages/skaff-lib/src/core/infra/npm-service.ts
+++ b/packages/skaff-lib/src/core/infra/npm-service.ts
@@ -1,8 +1,8 @@
 import { promisify } from "node:util";
-import { Result } from "../lib/types";
+import { Result } from "../../lib/types";
 import { execFile } from "node:child_process";
-import { logError } from "../lib/utils";
-import { getConfig } from "../lib";
+import { logError } from "../../lib/utils";
+import { getConfig } from "../../lib";
 
 const asyncExecFile = promisify(execFile);
 

--- a/packages/skaff-lib/src/core/infra/shell-service.ts
+++ b/packages/skaff-lib/src/core/infra/shell-service.ts
@@ -1,7 +1,7 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import { Result } from "../lib/types";
-import { logError } from "../lib/utils";
+import { Result } from "../../lib/types";
+import { logError } from "../../lib/utils";
 
 const asyncExec = promisify(exec);
 

--- a/packages/skaff-lib/src/core/projects/ProjectCreationManager.ts
+++ b/packages/skaff-lib/src/core/projects/ProjectCreationManager.ts
@@ -19,8 +19,8 @@ import {
 import {
   addAllAndRetrieveDiff,
   parseGitDiff,
-} from "../../services/git-service";
-import { TemplateGeneratorService } from "../../services/template-generator-service";
+} from "../infra/git-service";
+import { TemplateGeneratorService } from "../generation/template-generator-service";
 
 export class ProjectCreationManager {
   constructor(private readonly options?: ProjectCreationOptions) {}

--- a/packages/skaff-lib/src/core/projects/ProjectSettingsManager.ts
+++ b/packages/skaff-lib/src/core/projects/ProjectSettingsManager.ts
@@ -12,7 +12,7 @@ import { logError } from "../../lib/utils";
 import { Template } from "../../models/template";
 import { getRootTemplateRepository } from "../../repositories";
 import { deepSortObject } from "../../utils/shared-utils";
-import { makeDir } from "../../services/file-service";
+import { makeDir } from "../infra/file-service";
 
 interface LoadedProjectSettingsResult {
   settings: ProjectSettings;

--- a/packages/skaff-lib/src/core/projects/project-settings-service.ts
+++ b/packages/skaff-lib/src/core/projects/project-settings-service.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
-import { Result } from "../lib/types";
+import { Result } from "../../lib/types";
 import { ProjectSettings } from "@timonteutelink/template-types-lib";
-import { ProjectSettingsManager } from "../core/projects/ProjectSettingsManager";
+import { ProjectSettingsManager } from "./ProjectSettingsManager";
 
 export async function writeNewProjectSettings(
   absoluteProjectPath: string,

--- a/packages/skaff-lib/src/core/templates/Template.ts
+++ b/packages/skaff-lib/src/core/templates/Template.ts
@@ -16,14 +16,14 @@ import {
 } from "../../lib/types";
 import { backendLogger } from "../../lib/logger";
 import { logError } from "../../lib/utils";
-import { TemplateGeneratorService } from "../../services/template-generator-service";
+import { TemplateGeneratorService } from "../generation/template-generator-service";
 import { Project } from "../../models/project";
 import { parseProjectCreationResult } from "../projects/ProjectCreationFacade";
-import { getCacheDirPath } from "../../services/cache-service";
+import { getCacheDirPath } from "../infra/cache-service";
 import {
   getCommitHash,
   isGitRepoClean,
-} from "../../services/git-service";
+} from "../infra/git-service";
 
 export interface TemplateInit {
   config: GenericTemplateConfigModule;

--- a/packages/skaff-lib/src/core/templates/TemplateTreeBuilder.ts
+++ b/packages/skaff-lib/src/core/templates/TemplateTreeBuilder.ts
@@ -12,7 +12,7 @@ import {
   getCommitHash,
   getCurrentBranch,
   isGitRepoClean,
-} from "../../services/git-service";
+} from "../infra/git-service";
 import { Template } from "./Template";
 import { validateTemplate } from "./TemplateValidation";
 

--- a/packages/skaff-lib/src/core/templates/config/TemplateConfigLoader.ts
+++ b/packages/skaff-lib/src/core/templates/config/TemplateConfigLoader.ts
@@ -12,7 +12,7 @@ import {
   getHash,
   retrieveFromCache,
   saveToCache,
-} from "../../../services/cache-service";
+} from "../../../core/infra/cache-service";
 import { initEsbuild } from "../../../utils/get-esbuild";
 import { existsSync } from "node:fs";
 import { GenericTemplateConfigModule } from "../../../lib";

--- a/packages/skaff-lib/src/index.ts
+++ b/packages/skaff-lib/src/index.ts
@@ -4,6 +4,6 @@ export * from "./lib";
 export * from "./actions";
 
 export { findTemplate, projectSearchPathKey } from "./utils/shared-utils";
-export { getCacheDirPath, getCacheDir, pathInCache, saveToCache } from "./services/cache-service";
-export { getRemoteCommitHash } from "./services/git-service";
-export type { CacheKey } from "./services/cache-service";
+export { getCacheDirPath, getCacheDir, pathInCache, saveToCache } from "./core/infra/cache-service";
+export { getRemoteCommitHash } from "./core/infra/git-service";
+export type { CacheKey } from "./core/infra/cache-service";

--- a/packages/skaff-lib/src/lib/logger/server.ts
+++ b/packages/skaff-lib/src/lib/logger/server.ts
@@ -3,8 +3,8 @@ import path from "node:path";
 import { createLogger, format, transports } from "winston";
 import DailyRotateFile from "winston-daily-rotate-file";
 import type { LevelName, LogJSON } from "./types";
-import { makeDir } from "../../services/file-service";
-import { getCacheDirPath } from "../../services/cache-service";
+import { makeDir } from "../../core/infra/file-service";
+import { getCacheDirPath } from "../../core/infra/cache-service";
 
 const customLevels = {
   levels: {

--- a/packages/skaff-lib/src/models/project.ts
+++ b/packages/skaff-lib/src/models/project.ts
@@ -6,9 +6,9 @@ import {
 import path from "node:path";
 import { GitStatus, ProjectDTO, Result } from "../lib/types";
 import { logError, stringOrCallbackToString } from "../lib/utils";
-import { isGitRepo, loadGitStatus, getRemoteCommitHash } from "../services/git-service";
-import { loadProjectSettings } from "../services/project-settings-service";
-import { executeCommand } from "../services/shell-service";
+import { isGitRepo, loadGitStatus, getRemoteCommitHash } from "../core/infra/git-service";
+import { loadProjectSettings } from "../core/projects/project-settings-service";
+import { executeCommand } from "../core/infra/shell-service";
 import { Template } from "./template";
 import { backendLogger } from "../lib";
 

--- a/packages/skaff-lib/src/repositories/root-template-repository.ts
+++ b/packages/skaff-lib/src/repositories/root-template-repository.ts
@@ -7,7 +7,7 @@ import { logError } from "../lib/utils";
 import {
   cloneRepoBranchToCache,
   cloneRevisionToCache,
-} from "../services/git-service";
+} from "../core/infra/git-service";
 import {
   TemplateRegistry,
   TemplateTreeBuilder,

--- a/packages/skaff-lib/src/services/file-rollback-service.ts
+++ b/packages/skaff-lib/src/services/file-rollback-service.ts
@@ -1,1 +1,0 @@
-export { FileRollbackManager } from "../core/shared/FileRollbackManager";

--- a/packages/skaff-lib/tests/cache-service.test.ts
+++ b/packages/skaff-lib/tests/cache-service.test.ts
@@ -8,7 +8,7 @@ import {
   saveToCache,
   retrieveFromCache,
   runEraseCache,
-} from "../src/services/cache-service";
+} from "../src/core/infra/cache-service";
 
 describe("cache-service", () => {
   let cacheDir: string;

--- a/packages/skaff-lib/tests/file-service.test.ts
+++ b/packages/skaff-lib/tests/file-service.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import * as fs from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { makeDir } from "../src/services/file-service";
+import { makeDir } from "../src/core/infra/file-service";
 
 jest.mock("../src/lib/logger", () => ({
   backendLogger: { error: jest.fn(), info: jest.fn() },

--- a/packages/skaff-lib/tests/git-service.test.ts
+++ b/packages/skaff-lib/tests/git-service.test.ts
@@ -21,7 +21,7 @@ describe("git-service", () => {
   });
 
   it("detects git repository", async () => {
-    const { isGitRepo } = await import("../src/services/git-service");
+    const { isGitRepo } = await import("../src/core/infra/git-service");
     mockCheckIsRepo.mockResolvedValue(true);
     const result = await isGitRepo(".");
     expect(result).toEqual({ data: true });
@@ -31,7 +31,7 @@ describe("git-service", () => {
     const err: any = new Error("not repo");
     err.exitCode = 128;
     mockCheckIsRepo.mockRejectedValue(err);
-    const { isGitRepo } = await import("../src/services/git-service");
+    const { isGitRepo } = await import("../src/core/infra/git-service");
     const result = await isGitRepo(".");
     expect(result).toEqual({ data: false });
   });
@@ -40,7 +40,7 @@ describe("git-service", () => {
     const err: any = new Error("boom");
     err.exitCode = 1;
     mockCheckIsRepo.mockRejectedValue(err);
-    const { isGitRepo } = await import("../src/services/git-service");
+    const { isGitRepo } = await import("../src/core/infra/git-service");
     const result = await isGitRepo(".");
     expect(result).toHaveProperty("error");
   });


### PR DESCRIPTION
## Summary
- move the project diff, project settings, and template generator services into the core layer alongside their related modules
- relocate the remaining service implementations into a new core/infra folder and update all consumers and exports
- adjust tests and supporting files to reference the new paths

## Testing
- bun run test

------
https://chatgpt.com/codex/tasks/task_e_68d5d03c96a48325a2e7f6f6b25b21a6