### PR TITLE
Allow overriding template build commit hash

### DIFF
--- a/packages/skaff-lib/src/core/templates/TemplateTreeBuilder.ts
+++ b/packages/skaff-lib/src/core/templates/TemplateTreeBuilder.ts
@@ -221,6 +221,7 @@ function findRootTemplate(templatesMap: Record<string, Template>): Result<Templa
 export interface TemplateTreeBuilderOptions {
   repoUrl?: string;
   branchOverride?: string;
+  commitHash?: string;
 }
 
 @injectable()
@@ -241,6 +242,7 @@ export class TemplateTreeBuilder {
       absoluteRootDir,
       options.repoUrl,
       options.branchOverride,
+      options.commitHash,
     );
     if ("error" in contextResult) {
       return contextResult;
@@ -373,6 +375,7 @@ export class TemplateTreeBuilder {
     absoluteRootDir: string,
     repoUrl?: string,
     branchOverride?: string,
+    commitHashOverride?: string,
   ): Promise<Result<TemplateBuildContext>> {
     const absoluteBaseDir = path.dirname(absoluteRootDir);
     const isRepoCleanResult = await this.gitService.isGitRepoClean(
@@ -386,7 +389,9 @@ export class TemplateTreeBuilder {
       return { error: "Template dir is not clean" };
     }
 
-    const commitHashResult = await this.gitService.getCommitHash(absoluteRootDir);
+    const commitHashResult = commitHashOverride
+      ? { data: commitHashOverride }
+      : await this.gitService.getCommitHash(absoluteRootDir);
     if ("error" in commitHashResult) {
       return { error: commitHashResult.error };
     }


### PR DESCRIPTION
## Summary
- allow TemplateTreeBuilder to accept a commit hash override when building templates
- forward revision commit hashes from the root template repository when loading cached revisions

## Testing
- rm -rf dist && tsc -p tsconfig.json (from packages/skaff-lib)


------
https://chatgpt.com/codex/tasks/task_e_68d97e0622b483259a0a6528443ba263