### PR TITLE
Align CLI and web with new skaff-lib APIs

### DIFF
--- a/apps/cli/src/utils/revision-utils.ts
+++ b/apps/cli/src/utils/revision-utils.ts
@@ -1,8 +1,10 @@
-import { getRemoteCommitHash } from '@timonteutelink/skaff-lib';
+import { resolveGitService } from "@timonteutelink/skaff-lib";
+
+const gitService = resolveGitService();
 
 export async function resolveRevision(repoUrl: string, branchOrHash: string): Promise<string> {
   if (/^[0-9a-f]{40}$/i.test(branchOrHash)) return branchOrHash;
-  const res = await getRemoteCommitHash(repoUrl, branchOrHash);
+  const res = await gitService.getRemoteCommitHash(repoUrl, branchOrHash);
   if ('error' in res) throw new Error(res.error);
   return res.data;
 }

--- a/apps/web/src/app/actions/logs.ts
+++ b/apps/web/src/app/actions/logs.ts
@@ -3,7 +3,17 @@
 import fs from "node:fs";
 import path from "node:path";
 import readline from "node:readline";
-import { LevelName, LogFilter, LogJSON, Result, getCacheDirPath, getCacheDir, logError, serverLogger } from "@timonteutelink/skaff-lib";
+import {
+  LevelName,
+  LogFilter,
+  LogJSON,
+  Result,
+  logError,
+  resolveCacheService,
+  serverLogger,
+} from "@timonteutelink/skaff-lib";
+
+const cacheService = resolveCacheService();
 
 export async function logFromClient(data: {
   level: LevelName;
@@ -41,7 +51,11 @@ export async function fetchLogs(filter: LogFilter): Promise<Result<LogJSON[] | s
   const fromMs = from ? Date.parse(from) : null;
   const toMs = to ? Date.parse(to) : null;
 
-  const logPath = path.join(getCacheDirPath(), "logs", `skaff.${file}.log`);
+  const logPath = path.join(
+    cacheService.getCacheDirPath(),
+    "logs",
+    `skaff.${file}.log`,
+  );
 
   try {
     await fs.promises.access(logPath, fs.constants.R_OK);
@@ -89,7 +103,7 @@ export async function fetchLogs(filter: LogFilter): Promise<Result<LogJSON[] | s
 }
 
 export async function getAvailableLogDates(): Promise<Result<string[]>> {
-  const logDir = await getCacheDir();
+  const logDir = await cacheService.getCacheDir();
 
   if ("error" in logDir) {
     logError({ shortMessage: "Failed to get cache directory", error: logDir.error });

--- a/apps/web/src/lib/server-utils.ts
+++ b/apps/web/src/lib/server-utils.ts
@@ -1,9 +1,15 @@
-import { getConfig, getProjectRepository, backendLogger, Project, Result } from "@timonteutelink/skaff-lib";
+import {
+  backendLogger,
+  Project,
+  Result,
+  getConfig,
+  resolveProjectRepository,
+} from "@timonteutelink/skaff-lib";
 
 export async function findProject(
   projectName: string,
 ): Promise<Result<Project>> {
-  const projectRepository = await getProjectRepository();
+  const projectRepository = resolveProjectRepository();
   const config = await getConfig();
 
   let project: Project | null = null;
@@ -28,7 +34,7 @@ export async function findProject(
 }
 
 export async function listProjects(): Promise<Result<Project[]>> {
-  const projectRepository = await getProjectRepository();
+  const projectRepository = resolveProjectRepository();
   const config = await getConfig();
 
   const projectSearchPaths = config.PROJECT_SEARCH_PATHS;

--- a/bun.lock
+++ b/bun.lock
@@ -26,8 +26,8 @@
         "@oclif/core": "^4.5.3",
         "@oclif/plugin-help": "^6.2.32",
         "@oclif/plugin-plugins": "^5.4.46",
-        "@timonteutelink/skaff-lib": "0.0.72",
-        "@timonteutelink/template-types-lib": "0.0.49",
+        "@timonteutelink/skaff-lib": "0.0.73",
+        "@timonteutelink/template-types-lib": "0.0.50",
         "@types/node": "^22.18.1",
         "esbuild": "^0.25.9",
         "loglevel": "^1.9.2",
@@ -87,8 +87,8 @@
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tailwindcss/postcss": "^4.1.13",
-        "@timonteutelink/skaff-lib": "0.0.72",
-        "@timonteutelink/template-types-lib": "0.0.49",
+        "@timonteutelink/skaff-lib": "0.0.73",
+        "@timonteutelink/template-types-lib": "0.0.50",
         "@types/node": "^22.18.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -836,9 +836,9 @@
 
     "@timonteutelink/skaff": ["@timonteutelink/skaff@workspace:apps/cli"],
 
-    "@timonteutelink/skaff-lib": ["@timonteutelink/skaff-lib@0.0.72", "", { "dependencies": { "@langchain/langgraph": "^0.3.12", "@langchain/openai": "^0.5.18", "@timonteutelink/template-types-lib": "0.0.48", "@types/node": "^22.18.0", "esbuild": "^0.25.9", "fs-extra": "^11.3.1", "glob": "^11.0.3", "handlebars": "^4.7.8", "langchain": "^0.3.31", "loglevel": "^1.9.2", "semver": "^7.7.2", "simple-git": "^3.27.0", "typescript": "5.8.3", "winston": "^3.17.0", "winston-daily-rotate-file": "^5.0.0", "yaml": "^2.8.1", "zod": "^3.25.76", "zod-to-json-schema": "^3.24.6" } }, "sha512-a3JJkx+Akvw5cyJp3+GaF1BTi24RaTXOn1Rh9dSVLl9cnVv9pNq68rchcTDc6tb0I1X+rdQYPsrlVbFRtZco5A=="],
+    "@timonteutelink/skaff-lib": ["@timonteutelink/skaff-lib@0.0.73", "", { "dependencies": { "@langchain/langgraph": "^0.3.12", "@langchain/openai": "^0.5.18", "@timonteutelink/template-types-lib": "0.0.50", "@types/node": "^22.18.0", "esbuild": "^0.25.9", "fs-extra": "^11.3.1", "glob": "^11.0.3", "handlebars": "^4.7.8", "langchain": "^0.3.31", "loglevel": "^1.9.2", "reflect-metadata": "^0.2.2", "semver": "^7.7.2", "simple-git": "^3.27.0", "tsyringe": "^4.9.0", "typescript": "5.8.3", "winston": "^3.17.0", "winston-daily-rotate-file": "^5.0.0", "yaml": "^2.8.1", "zod": "^3.25.76", "zod-to-json-schema": "^3.24.6" } }, "sha512-5MKFD19bE3gGnanlYkB+GAXBIUgu9ZDjP0VShYghWZdYsiGrFYEIgjUxh4HTV86RAZYTRlPasYPTlrEfQSBKTg=="],
 
-    "@timonteutelink/template-types-lib": ["@timonteutelink/template-types-lib@0.0.49", "", { "peerDependencies": { "handlebars": "^4.7.8", "zod": "^3.25.76" } }, "sha512-evUQ5WHbSA+VFwZQ1/LPXE0D5p1SniEO+L3y27Tqi5OHf12McKEIX4fmL3ftPl2c5g95K+M6otmixqM7bLAOgQ=="],
+    "@timonteutelink/template-types-lib": ["@timonteutelink/template-types-lib@0.0.50", "", { "peerDependencies": { "handlebars": "^4.7.8", "zod": "^3.25.76" } }, "sha512-/BH7ZpEUo1tStMe8iKz2ZhC7xtKnXO007OsNOZTCoAEZFvgAAhz4psZKBX7iAaZ/6u+ekvQnhTXWrFVAkjTTYA=="],
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
@@ -1924,6 +1924,8 @@
 
     "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
 
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
+
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
     "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
@@ -2113,6 +2115,8 @@
     "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
@@ -2319,8 +2323,6 @@
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@timonteutelink/skaff/typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
-
-    "@timonteutelink/skaff-lib/@timonteutelink/template-types-lib": ["@timonteutelink/template-types-lib@0.0.48", "", { "peerDependencies": { "handlebars": "^4.7.8", "zod": "^3.25.76" } }, "sha512-7sGRWKCCz/awlGNmalTra7IFbsIjO16XjXRj+JNi1wZaPKTqWlOsQxB93rQPIszaFMva1XO7c6H9D8OutoOh5Q=="],
 
     "@timonteutelink/skaff-lib/fs-extra": ["fs-extra@11.3.2", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A=="],
 
@@ -2849,6 +2851,8 @@
     "tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "ts-node/diff": ["diff@4.0.2", "", {}, "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="],
+
+    "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "validate-npm-package-license/spdx-expression-parse": ["spdx-expression-parse@3.0.1", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q=="],
 


### PR DESCRIPTION
## Summary
- switch CLI diff utilities to use the CacheService instance from the refactored skaff-lib
- update CLI revision helper to call the GitService for remote hashes
- adjust web log and project helpers to resolve cache and project repositories from the container
- refresh bun.lock to pull the latest skaff-lib release used by the apps

## Testing
- bun run build (apps/cli)
- bun run build (apps/web)

------
https://chatgpt.com/codex/tasks/task_e_68d97f8f87008325af0ee0b1dadbd738