### PR TITLE
feat: allow listing templates from template repositories

### DIFF
--- a/apps/cli/src/commands/template/list.ts
+++ b/apps/cli/src/commands/template/list.ts
@@ -1,12 +1,40 @@
-import { getTemplates } from '@timonteutelink/skaff-lib';
+import { Flags } from '@oclif/core';
+import { getTemplates, listTemplatesInRepo } from '@timonteutelink/skaff-lib';
 
 import Base from '../../base-command.js';
 
 export default class TemplateList extends Base {
-  static description = 'List all loaded root templates';
+  static description = 'List loaded root templates or inspect a template repository';
+  static flags = {
+    ...Base.flags,
+    repo: Flags.string({
+      description: 'Git repository URL or path to inspect for templates',
+    }),
+    branch: Flags.string({
+      description: 'Branch to check out when using --repo',
+    }),
+  };
 
   async run() {
-    await this.parse(TemplateList);          // parses global flags
+    const { flags } = await this.parse(TemplateList);
+
+    if (flags.repo) {
+      const branch = (flags.branch as string | undefined) ?? 'main';
+      const res = await listTemplatesInRepo(flags.repo, branch);
+      if ('error' in res) this.error(res.error, { exit: 1 });
+
+      this.output(
+        res.data.map((template) => ({
+          revision: template.commitHash,
+          description: template.config.templateConfig.description,
+          name: template.config.templateConfig.name,
+          isLocal: template.isLocal,
+          branch: template.branch ?? branch,
+          repoUrl: template.repoUrl ?? flags.repo,
+        })),
+      );
+      return;
+    }
 
     const res = await getTemplates();
     if ('error' in res) this.error(res.error, { exit: 1 });

--- a/packages/skaff-lib/src/actions/template/index.ts
+++ b/packages/skaff-lib/src/actions/template/index.ts
@@ -7,3 +7,4 @@ export { loadProjectTemplateRevision } from "./load-project-template-revision";
 export { eraseCache } from "./erase-cache";
 export { reloadTemplates } from "./reload-templates";
 export { loadTemplateFromRepo } from "./load-from-repo";
+export { listTemplatesInRepo } from "./list-from-repo";

--- a/packages/skaff-lib/src/actions/template/list-from-repo.ts
+++ b/packages/skaff-lib/src/actions/template/list-from-repo.ts
@@ -1,0 +1,11 @@
+import { Result } from "../../lib";
+import { Template } from "../../models";
+import { resolveRootTemplateRepository } from "../../repositories";
+
+export async function listTemplatesInRepo(
+  repoUrl: string,
+  branch: string = "main",
+): Promise<Result<Template[]>> {
+  const rootTemplateRepository = resolveRootTemplateRepository();
+  return await rootTemplateRepository.listTemplatesInRepo(repoUrl, branch);
+}


### PR DESCRIPTION
## Summary
- add a `--repo` flag to `skaff template list` so automation can enumerate remote templates without loading them first
- validate and return templates directly from a repository through the root template repository
- expose the new listing action from `@timonteutelink/skaff-lib` for consumers

## Testing
- bun run test

------
https://chatgpt.com/codex/tasks/task_e_68d98407ffb483288dcbe070437f2365

Fixes #29