### PR TITLE
Fix revision load path for hyphenated template directories

### DIFF
--- a/packages/skaff-lib/src/repositories/root-template-repository.ts
+++ b/packages/skaff-lib/src/repositories/root-template-repository.ts
@@ -239,10 +239,14 @@ export class RootTemplateRepository {
       return saveRevisionInCacheResult;
     }
 
+    const templateRelativePath = path.relative(
+      path.dirname(sourceTemplate.absoluteBaseDir),
+      sourceTemplate.absoluteDir,
+    );
+
     const newTemplatePath = path.join(
       saveRevisionInCacheResult.data,
-      "root-templates",
-      templateName,
+      templateRelativePath,
     );
 
     const templateResult = await this.templateTreeBuilder.build(


### PR DESCRIPTION
## Summary
- ensure template revisions are reloaded using the actual template directory path instead of the template name

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d985bb6b648325b8f2dbbc18c2f8d3