### PR TITLE
feat: load GitHub template repos from settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ skaff --help
 ![Preview Patching](assets/previewPatching.png)
 - **Multi‑platform distribution.** Use it instantly via `npx` or `bunx`, install globally with npm or bun, download a prebuilt binary, or run it as a reproducible Nix flake.
 - **Visual Web UI.** A Next.js powered interface allows you to browse templates, fill in form fields, preview the resulting file tree or diff, and apply patches without touching the terminal
-- **Flexible configuration.** Configure where your templates live and where to create projects through a simple JSON config or environment variables like `TEMPLATE_DIR_PATHS`, `PROJECT_SEARCH_PATHS`
-- **Language agnostic.** Templates can target any stack like FastAPI, React, Go and Rust as long as they ship a schema. Additional template repositories can be referenced with `--repo`, and GitHub template retrieval is on the roadmap.
+- **Flexible configuration.** Configure where your templates live and where to create projects through a simple JSON config or environment variables like `TEMPLATE_DIR_PATHS`, `PROJECT_SEARCH_PATHS`. Point Skaff at local directories or GitHub repositories and it will clone the latest templates for you.
+- **Language agnostic.** Templates can target any stack like FastAPI, React, Go and Rust as long as they ship a schema. Additional template repositories can be referenced with `--repo` or configured once in `settings.json`.
 
 ## How it works
 

--- a/packages/docs/src/docs/guides/cli/setup.mdx
+++ b/packages/docs/src/docs/guides/cli/setup.mdx
@@ -12,6 +12,9 @@ Skaff reads configuration from three sources, merged in this order: environment 
 # add directories that contain template repositories
 skaff config add ~/skaff-example-templates TEMPLATE_DIR_PATHS
 
+# add a GitHub repository (defaults to the main branch)
+skaff config add github:timonteutelink/skaff-example-templates TEMPLATE_DIR_PATHS
+
 # optionally tell Skaff where to find existing projects
 skaff config add ~/code PROJECT_SEARCH_PATHS
 

--- a/packages/docs/src/docs/guides/reference/configuration.mdx
+++ b/packages/docs/src/docs/guides/reference/configuration.mdx
@@ -8,7 +8,7 @@ Skaff stores user configuration in JSON at `~/.config/skaff/settings.json`. Envi
 
 | Key                    | Type       | Description                                                                                                              |
 | ---------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `TEMPLATE_DIR_PATHS`   | `string[]` | Directories that contain template repositories. Skaff scans each for `root-templates/`.                                  |
+| `TEMPLATE_DIR_PATHS`   | `string[]` | Directories or Git repositories that contain templates. Skaff scans directories for `root-templates/` and clones remote repositories such as `github:org/templates#branch`. |
 | `PROJECT_SEARCH_PATHS` | `string[]` | Locations Skaff inspects when running `skaff project ls`. Helpful when projects live in multiple workspaces.             |
 | `NPM_PATH`             | `string`   | Command used to execute template-defined scripts. Defaults to `npm`; set to `bunx`, `pnpm`, or another runner as needed. |
 
@@ -17,6 +17,9 @@ Environment variable formats:
 ```bash
 # multiple directories
 export TEMPLATE_DIR_PATHS="~/templates:/srv/templates"
+
+# mix local directories and remote GitHub repositories (branch optional)
+export TEMPLATE_DIR_PATHS="~/templates,github:timonteutelink/example-templates#main"
 
 # custom config location
 export SKAFF_CONFIG_PATH="$PWD/.skaff/settings.json"


### PR DESCRIPTION
## Summary
- allow TEMPLATE_DIR_PATHS entries to reference GitHub repositories or other remote git URLs
- refresh the template loader to clone configured remotes and keep manual additions intact
- document the new configuration options in the README and docs

## Testing
- bunx tsc -p packages/skaff-lib/tsconfig.json

------
https://chatgpt.com/codex/tasks/task_e_68d9896ab8c88328a2e1711c47987d86