### PR TITLE
feat: load templates from templates directory

### DIFF
--- a/packages/docs/src/docs/guides/authoring/workflow.mdx
+++ b/packages/docs/src/docs/guides/authoring/workflow.mdx
@@ -9,7 +9,7 @@ A Skaff template is a directory with a TypeScript config file and a set of files
 ## Directory layout
 
 ```
-root-templates/
+templates/
   service-template/
     templateConfig.ts
     templates/
@@ -21,7 +21,7 @@ root-templates/
         templates/
 ```
 
-- **`templateConfig.ts`** exports a `TemplateConfigModule`. Define metadata (`name`, `description`, `specVersion`), the Zod schemas for user input (`templateSettingsSchema` and `templateFinalSettingsSchema`), and the `mapFinalSettings` function that produces the values used during rendering. Set `targetPath` so Skaff knows where files land.
+- **`templateConfig.ts`** exports a `TemplateConfigModule`. Define metadata (`name`, `description`, `specVersion`), the Zod schemas for user input (`templateSettingsSchema` and `templateFinalSettingsSchema`), and the `mapFinalSettings` function that produces the values used during rendering. Set `isRootTemplate` to `true` for templates that can start a project and configure `targetPath` so Skaff knows where files land.
 - **`templates/`** holds files to render. Append `.hbs` to process a file with Handlebars; omit it for plain copies. Skaff copies the directory structure relative to `targetPath`.
 - **`subtemplates/`** hosts optional modules. Structure them the same way as root templates so they can run independently.
 
@@ -56,6 +56,7 @@ const templateConfig: TemplateConfigModule<
     author: "Example team",
     description: "Production-ready service starter",
     specVersion: "1.0.0",
+    isRootTemplate: true,
   },
   templateSettingsSchema,
   templateFinalSettingsSchema: templateSettingsSchema,

--- a/packages/docs/src/docs/guides/getting-started/core-concepts.mdx
+++ b/packages/docs/src/docs/guides/getting-started/core-concepts.mdx
@@ -8,10 +8,10 @@ A few building blocks explain how Skaff keeps generated projects reproducible an
 
 ## Templates and repositories
 
-Templates live in Git repositories under `root-templates/<name>/`. Each template exports a `templateConfig.ts` module alongside a `templates/` directory (and optional `subtemplates/`). Skaff reads this metadata to know how to prompt for input, where to write files, and which hooks to run.
+Templates live in Git repositories under `templates/<name>/`. Each template exports a `templateConfig.ts` module alongside a `templates/` directory (and optional `subtemplates/`). Skaff reads this metadata to know how to prompt for input, where to write files, and which hooks to run.
 
 ```text
-root-templates/
+templates/
   nextjs-app/
     templateConfig.ts
     templates/

--- a/packages/docs/src/docs/guides/reference/configuration.mdx
+++ b/packages/docs/src/docs/guides/reference/configuration.mdx
@@ -8,7 +8,7 @@ Skaff stores user configuration in JSON at `~/.config/skaff/settings.json`. Envi
 
 | Key                    | Type       | Description                                                                                                              |
 | ---------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `TEMPLATE_DIR_PATHS`   | `string[]` | Directories or Git repositories that contain templates. Skaff scans directories for `root-templates/` and clones remote repositories such as `github:org/templates#branch`. |
+| `TEMPLATE_DIR_PATHS`   | `string[]` | Directories or Git repositories that contain templates. Skaff scans directories for `templates/` and clones remote repositories such as `github:org/templates#branch`. |
 | `PROJECT_SEARCH_PATHS` | `string[]` | Locations Skaff inspects when running `skaff project ls`. Helpful when projects live in multiple workspaces.             |
 | `NPM_PATH`             | `string`   | Command used to execute template-defined scripts. Defaults to `npm`; set to `bunx`, `pnpm`, or another runner as needed. |
 

--- a/packages/skaff-lib/src/core/infra/git-service.ts
+++ b/packages/skaff-lib/src/core/infra/git-service.ts
@@ -211,7 +211,7 @@ export class GitService {
     template: Template,
     revisionHash: string,
   ): Promise<Result<string>> {
-    const repoDir = path.dirname(template.absoluteBaseDir); //TODO absoluteBaseDir should point to root of git dir now is root-templates.
+    const repoDir = path.dirname(template.absoluteBaseDir); //TODO absoluteBaseDir should point to root of git dir; currently it resolves to the templates directory.
     const repoName = path.basename(repoDir);
 
     const destDirName = `${repoName}-${revisionHash}`;

--- a/packages/skaff-lib/src/repositories/root-template-repository.ts
+++ b/packages/skaff-lib/src/repositories/root-template-repository.ts
@@ -1,3 +1,4 @@
+import type { Dirent } from "node:fs";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 
@@ -28,7 +29,7 @@ export const defaultTemplatePathsProvider: TemplatePathsProvider = async () => {
 
 // TODO: findTemplate and loadRevision should only load that specific template not load all templates
 
-// now only stores the root templates at: <templateDirPath>/root-templates/*
+// now only stores the root templates at: <templateDirPath>/templates/*
 // later also store reference to files and generic templates to allow direct instantiation without saving state of subtemplates
 type RemoteRepoSource = "config" | "manual";
 
@@ -194,21 +195,26 @@ export class RootTemplateRepository {
     ];
     for (const templatePath of paths) {
       const repoInfo = this.remoteRepos.find((r) => r.path === templatePath);
-      const rootTemplateDirsPath = path.join(templatePath, "root-templates");
-      let rootTemplateDirs: string[] = [];
+      const templatesRootDir = path.join(templatePath, "templates");
+      let templateEntries: Dirent[] = [];
       try {
-        rootTemplateDirs = await fs.readdir(rootTemplateDirsPath);
+        templateEntries = await fs.readdir(templatesRootDir, {
+          withFileTypes: true,
+        });
       } catch (error) {
         backendLogger.warn(
-          `Failed to read root template directories at ${rootTemplateDirsPath}.`,
+          `Failed to read template directories at ${templatesRootDir}.`,
           error,
         );
         continue;
       }
-      for (const rootTemplateDir of rootTemplateDirs) {
+      for (const entry of templateEntries) {
+        if (!entry.isDirectory()) {
+          continue;
+        }
         const rootTemplateDirPath = path.join(
-          rootTemplateDirsPath,
-          rootTemplateDir,
+          templatesRootDir,
+          entry.name,
         );
         try {
           const stat = await fs.stat(rootTemplateDirPath);
@@ -275,35 +281,27 @@ export class RootTemplateRepository {
     }
 
     const repoPath = cloneResult.data;
-    const rootTemplatesDir = path.join(repoPath, "root-templates");
+    const rootTemplatesDir = path.join(repoPath, "templates");
 
-    let rootTemplateDirs: string[];
+    let templateEntries: Dirent[];
     try {
-      rootTemplateDirs = await fs.readdir(rootTemplatesDir);
+      templateEntries = await fs.readdir(rootTemplatesDir, {
+        withFileTypes: true,
+      });
     } catch (error) {
-      const message = `Failed to read root template directories at ${rootTemplatesDir}`;
+      const message = `Failed to read template directories at ${rootTemplatesDir}`;
       logError({ error, shortMessage: message });
       return { error: message };
     }
 
     const templates: Template[] = [];
 
-    for (const dir of rootTemplateDirs) {
-      const templateDir = path.join(rootTemplatesDir, dir);
-      let stat;
-      try {
-        stat = await fs.stat(templateDir);
-      } catch (error) {
-        backendLogger.warn(
-          `Failed to read potential root template directory at ${templateDir}.`,
-          error,
-        );
+    for (const entry of templateEntries) {
+      if (!entry.isDirectory()) {
         continue;
       }
 
-      if (!stat.isDirectory()) {
-        continue;
-      }
+      const templateDir = path.join(rootTemplatesDir, entry.name);
 
       const templateResult = await this.templateTreeBuilder.build(templateDir, {
         repoUrl,

--- a/packages/skaff-lib/tests/helpers/template-fixtures.ts
+++ b/packages/skaff-lib/tests/helpers/template-fixtures.ts
@@ -211,6 +211,7 @@ interface TemplateModuleOptions {
     description?: string;
     specVersion: string;
     multiInstance?: boolean;
+    isRootTemplate?: boolean;
   }>;
   settingsFields?: Record<string, TemplateSettingsFieldDefinition>;
   mapFinalSettingsBody?: string;

--- a/packages/template-types-lib/README.md
+++ b/packages/template-types-lib/README.md
@@ -26,6 +26,7 @@ const templateConfig: TemplateConfig = {
   name: "hello-world",
   author: "Example Templates",
   specVersion: "1.0.0",
+  isRootTemplate: true,
 };
 
 const templateModule: TemplateConfigModule<

--- a/packages/template-types-lib/src/types/template-config-types.ts
+++ b/packages/template-types-lib/src/types/template-config-types.ts
@@ -43,6 +43,11 @@ export const templateConfigSchema = z.object({
     .describe(
       "Whether the template can be used multiple times in the same project. Defaults to false.",
     ),
+  isRootTemplate: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("Whether this template can be instantiated as the root template."),
 });
 
 // assuming output same type as input


### PR DESCRIPTION
## Summary
- add an `isRootTemplate` flag to template configs and document how to mark root templates
- load template definitions from the top-level `templates/` directory and ignore deeper nesting
- refresh authoring docs to describe the new layout

## Testing
- bun run test (packages/skaff-lib)


------
https://chatgpt.com/codex/tasks/task_e_69091fa747788328b51396aabed2705f