### PR TITLE
Normalize Git repository specifiers across loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ skaff --help
 ![Preview Patching](assets/previewPatching.png)
 - **Multi‑platform distribution.** Use it instantly via `npx` or `bunx`, install globally with npm or bun, download a prebuilt binary, or run it as a reproducible Nix flake.
 - **Visual Web UI.** A Next.js powered interface allows you to browse templates, fill in form fields, preview the resulting file tree or diff, and apply patches without touching the terminal
-- **Flexible configuration.** Configure where your templates live and where to create projects through a simple JSON config or environment variables like `TEMPLATE_DIR_PATHS`, `PROJECT_SEARCH_PATHS`. Point Skaff at local directories or GitHub repositories and it will clone the latest templates for you.
+- **Flexible configuration.** Configure where your templates live and where to create projects through a simple JSON config or environment variables like `TEMPLATE_DIR_PATHS`, `PROJECT_SEARCH_PATHS`. Point Skaff at local directories or GitHub repositories and it will clone the latest templates for you. Skaff recognises GitHub repositories declared as shorthand (`github:`/`gh:`), full HTTPS or SSH URLs, and even `file://` URIs. Append `@branch` (for shorthands) or `#branch` (for URLs) to pin a specific branch when loading templates.
 - **Language agnostic.** Templates can target any stack like FastAPI, React, Go and Rust as long as they ship a schema. Additional template repositories can be referenced with `--repo` or configured once in `settings.json`.
 
 ## How it works

--- a/packages/skaff-lib/src/core/templates/config/TemplateConfigLoader.ts
+++ b/packages/skaff-lib/src/core/templates/config/TemplateConfigLoader.ts
@@ -12,6 +12,7 @@ import { inject, injectable } from "tsyringe";
 
 import { existsSync } from "node:fs";
 import { GenericTemplateConfigModule } from "../../../lib";
+import { normalizeGitRepositorySpecifier } from "../../../lib/git-repo-spec";
 import { getSkaffContainer } from "../../../di/container";
 import {
   CacheServiceToken,
@@ -87,11 +88,12 @@ function extractTemplateRefEntries(raw: unknown): TemplateRefEntry[] {
     if (typeof repoUrl === "string" && typeof pathValue === "string") {
       const branch =
         typeof record.branch === "string" ? record.branch : undefined;
+      const normalized = normalizeGitRepositorySpecifier(repoUrl);
       return [
         {
           type: "remote",
-          repoUrl,
-          branch,
+          repoUrl: normalized?.repoUrl ?? repoUrl,
+          branch: normalized?.branch ?? branch,
           path: pathValue,
         },
       ];

--- a/packages/skaff-lib/src/lib/git-repo-spec.ts
+++ b/packages/skaff-lib/src/lib/git-repo-spec.ts
@@ -1,0 +1,126 @@
+const GITHUB_PREFIX_PATTERN = /^(github|gh):/i;
+const REMOTE_SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
+const SCP_LIKE_PATTERN = /^[^@\s]+@[^:\s]+:/;
+
+export interface NormalizedGitRepositorySpecifier {
+  repoUrl: string;
+  branch?: string;
+}
+
+function extractBranchSuffix(
+  spec: string,
+): NormalizedGitRepositorySpecifier | null {
+  let repoUrl = spec.trim();
+  if (!repoUrl) {
+    return null;
+  }
+
+  let branch: string | undefined;
+
+  const hashIndex = repoUrl.lastIndexOf("#");
+  if (hashIndex !== -1) {
+    const possibleBranch = repoUrl.slice(hashIndex + 1).trim();
+    repoUrl = repoUrl.slice(0, hashIndex).trim();
+    if (possibleBranch.length > 0) {
+      branch = possibleBranch;
+    }
+  }
+
+  if (!repoUrl) {
+    return null;
+  }
+
+  return { repoUrl, branch };
+}
+
+function normalizeGithubRepoPath(raw: string): string | null {
+  const cleaned = raw
+    .trim()
+    .replace(/^\/+/, "")
+    .replace(/\.git$/i, "")
+    .replace(/\/+$/g, "");
+
+  if (!cleaned) {
+    return null;
+  }
+
+  const segments = cleaned.split("/").filter(Boolean);
+  if (segments.length < 2) {
+    return null;
+  }
+
+  return segments.join("/");
+}
+
+function parseGithubSpecifier(
+  raw: string,
+): NormalizedGitRepositorySpecifier | null {
+  const remainder = raw.replace(GITHUB_PREFIX_PATTERN, "");
+  const match = remainder.match(/^(?<repo>[^@#]+)(?:[@#](?<branch>.+))?$/);
+  if (!match || !match.groups) {
+    return null;
+  }
+
+  const repoPath = normalizeGithubRepoPath(match.groups.repo ?? "");
+  if (!repoPath) {
+    return null;
+  }
+
+  const branch = match.groups.branch?.trim();
+  return {
+    repoUrl: `https://github.com/${repoPath}.git`,
+    branch: branch ? branch : undefined,
+  };
+}
+
+function parseExplicitRemote(
+  raw: string,
+): NormalizedGitRepositorySpecifier | null {
+  const normalized = extractBranchSuffix(raw);
+  if (!normalized) {
+    return null;
+  }
+
+  return normalized.repoUrl ? normalized : null;
+}
+
+export function normalizeGitRepositorySpecifier(
+  raw: string,
+): NormalizedGitRepositorySpecifier | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (GITHUB_PREFIX_PATTERN.test(trimmed)) {
+    return parseGithubSpecifier(trimmed);
+  }
+
+  if (REMOTE_SCHEME_PATTERN.test(trimmed) || SCP_LIKE_PATTERN.test(trimmed)) {
+    return parseExplicitRemote(trimmed);
+  }
+
+  return null;
+}
+
+export type TemplatePathEntry =
+  | { kind: "local"; path: string }
+  | { kind: "remote"; repoUrl: string; branch?: string };
+
+export function parseTemplatePathEntry(raw: string): TemplatePathEntry | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const normalized = normalizeGitRepositorySpecifier(trimmed);
+  if (normalized) {
+    return {
+      kind: "remote",
+      repoUrl: normalized.repoUrl,
+      branch: normalized.branch,
+    };
+  }
+
+  return { kind: "local", path: trimmed };
+}

--- a/packages/skaff-lib/tests/git-repo-spec.test.ts
+++ b/packages/skaff-lib/tests/git-repo-spec.test.ts
@@ -1,0 +1,77 @@
+import {
+  normalizeGitRepositorySpecifier,
+  parseTemplatePathEntry,
+} from "../src/lib/git-repo-spec";
+
+describe("normalizeGitRepositorySpecifier", () => {
+  it("normalizes github shorthand", () => {
+    const result = normalizeGitRepositorySpecifier("github:owner/repo");
+    expect(result).toEqual({
+      repoUrl: "https://github.com/owner/repo.git",
+      branch: undefined,
+    });
+  });
+
+  it("supports gh shorthand with branch", () => {
+    const result = normalizeGitRepositorySpecifier("gh:org/project@dev");
+    expect(result).toEqual({
+      repoUrl: "https://github.com/org/project.git",
+      branch: "dev",
+    });
+  });
+
+  it("parses branch fragments on remote URLs", () => {
+    const result = normalizeGitRepositorySpecifier(
+      "https://github.com/org/project.git#feature",
+    );
+    expect(result).toEqual({
+      repoUrl: "https://github.com/org/project.git",
+      branch: "feature",
+    });
+  });
+
+  it("handles ssh style repositories", () => {
+    const result = normalizeGitRepositorySpecifier(
+      "git@github.com:org/project.git",
+    );
+    expect(result).toEqual({
+      repoUrl: "git@github.com:org/project.git",
+      branch: undefined,
+    });
+  });
+
+  it("supports file scheme repositories", () => {
+    const result = normalizeGitRepositorySpecifier("file:///tmp/repo#main");
+    expect(result).toEqual({ repoUrl: "file:///tmp/repo", branch: "main" });
+  });
+
+  it("returns null for plain paths", () => {
+    const result = normalizeGitRepositorySpecifier("./local/path");
+    expect(result).toBeNull();
+  });
+});
+
+describe("parseTemplatePathEntry", () => {
+  it("treats github shorthand as remote", () => {
+    const result = parseTemplatePathEntry("github:owner/repo@dev");
+    expect(result).toEqual({
+      kind: "remote",
+      repoUrl: "https://github.com/owner/repo.git",
+      branch: "dev",
+    });
+  });
+
+  it("treats local paths as local entries", () => {
+    const result = parseTemplatePathEntry("../templates");
+    expect(result).toEqual({ kind: "local", path: "../templates" });
+  });
+
+  it("recognizes file scheme as remote", () => {
+    const result = parseTemplatePathEntry("file:///srv/templates");
+    expect(result).toEqual({
+      kind: "remote",
+      repoUrl: "file:///srv/templates",
+      branch: undefined,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared parser that normalizes GitHub, SSH, HTTPS, and file repository specifiers
- update root template repository and template config loader to use the shared normalization logic
- document the supported specifiers and cover them with unit tests

## Testing
- `cd packages/skaff-lib && bun run test` *(fails: TypeError resolveFileSystemService is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_690a6524fd9083288a1be7d4db501273