### PR TITLE
Rename project name to project repository name

### DIFF
--- a/apps/cli/src/commands/project/clone.ts
+++ b/apps/cli/src/commands/project/clone.ts
@@ -9,10 +9,10 @@ import { viewParsedDiffWithGit } from '../../utils/diff-utils.js';
 
 export default class InstantiationProjectClone extends Base {
   static args = {
-    newProjectName: Args.string({ required: true }),
+    newProjectRepositoryName: Args.string({ required: true }),
     oldProjectPath: Args.string({ required: true }),
   };
-static description = 'Generate a new project from an existing one';
+  static description = 'Generate a new project repository from an existing one';
 
   async run() {
     const { args } = await this.parse(InstantiationProjectClone);
@@ -29,7 +29,7 @@ static description = 'Generate a new project from an existing one';
     const res = await generateNewProjectFromExisting(
       oldProject.data,
       process.cwd(),
-      args.newProjectName,
+      args.newProjectRepositoryName,
       { git: true },
     );
     if ('error' in res) this.error(res.error, { exit: 1 });

--- a/apps/cli/src/commands/project/from-settings.ts
+++ b/apps/cli/src/commands/project/from-settings.ts
@@ -7,10 +7,10 @@ import { viewParsedDiffWithGit } from '../../utils/diff-utils.js';
 
 export default class InstantiationProjectFromSettings extends Base {
   static args = {
-    newProjectName: Args.string({ required: true }),
+    newProjectRepositoryName: Args.string({ required: true }),
     settingsFileOrJson: Args.string({ required: true }),
   };
-static description = 'Generate a project entirely from a ProjectSettings JSON';
+  static description = 'Generate a project repository entirely from a ProjectSettings JSON';
 
   async run() {
     const { args } = await this.parse(InstantiationProjectFromSettings);
@@ -22,7 +22,7 @@ static description = 'Generate a project entirely from a ProjectSettings JSON';
     const res = await generateNewProjectFromSettings(
       settingsStr,
       process.cwd(),
-      args.newProjectName,
+      args.newProjectRepositoryName,
       { git: true },
     );
     if ('error' in res) this.error(res.error, { exit: 1 });

--- a/apps/cli/src/commands/project/ls.ts
+++ b/apps/cli/src/commands/project/ls.ts
@@ -5,12 +5,12 @@ import Base from '../../base-command.js';
 
 export default class ProjectLs extends Base {
   static description =
-    'List projects in the current directory (use --project PATH to scope the search, --name to filter by project name)';
+    'List projects in the current directory (use --project PATH to scope the search, --name to filter by project repository name)';
   static flags = {
     ...Base.flags,
     name: Flags.string({
       char: 'n',
-      description: 'Filter by project name',
+      description: 'Filter by project repository name',
     }),
   };
 
@@ -23,7 +23,7 @@ export default class ProjectLs extends Base {
     let projects = res.data;
     if (flags.name) {
       projects = projects.filter(
-        p => p.instantiatedProjectSettings.projectName === flags.name,
+        p => p.instantiatedProjectSettings.projectRepositoryName === flags.name,
       );
       if (projects.length === 0)
         this.error('No projects found with the given name', { exit: 1 });

--- a/apps/cli/src/commands/project/new.ts
+++ b/apps/cli/src/commands/project/new.ts
@@ -7,10 +7,10 @@ import { readUserTemplateSettings } from '../../utils/template-utils.js';
 
 export default class InstantiationProjectNew extends Base {
   static args = {
-    projectName: Args.string({ required: true }),
+    projectRepositoryName: Args.string({ required: true }),
     templateName: Args.string({ required: true }),
   };
-  static description = 'Create a new project from a template';
+  static description = 'Create a new project repository from a template';
   static flags = {
     ...Base.flags,
     settings: Flags.string({
@@ -37,7 +37,7 @@ export default class InstantiationProjectNew extends Base {
     );
 
     const res = await generateNewProject(
-      args.projectName,
+      args.projectRepositoryName,
       args.templateName,
       process.cwd(),
       settings,

--- a/apps/cli/src/commands/template/project-revision.ts
+++ b/apps/cli/src/commands/template/project-revision.ts
@@ -32,7 +32,7 @@ export default class TemplateProjectRevision extends Base {
 
     this.output({
       description: tpl.config.templateConfig.description,
-      project: project.data.instantiatedProjectSettings.projectName,
+      project: project.data.instantiatedProjectSettings.projectRepositoryName,
       revision: tpl.commitHash,
       template: tpl.config.templateConfig.name,
     });

--- a/apps/web/src/app/(with-sidebar)/projects/page.tsx
+++ b/apps/web/src/app/(with-sidebar)/projects/page.tsx
@@ -39,7 +39,7 @@ import {
   type ProjectDTO,
   type TemplateDTO,
 } from "@timonteutelink/skaff-lib/browser";
-import { projectNameRegex } from "@timonteutelink/template-types-lib";
+import { projectRepositoryNameRegex } from "@timonteutelink/template-types-lib";
 import { PlusCircle } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -58,12 +58,12 @@ const columnMapping: FieldInfo<ProjectDTO>[] = [
 ];
 
 const formSchema = z.object({
-  projectName: z
+  projectRepositoryName: z
     .string()
-    .min(1, "Project name is required")
+    .min(1, "Project repository name is required")
     .regex(
-      projectNameRegex,
-      "Project name can only contain letters, numbers, dashes and underscores.",
+      projectRepositoryNameRegex,
+      "Project repository name can only contain letters, numbers, dashes and underscores.",
     ),
   template: z.string().min(1, "Template is required"),
   directory: z.string().min(1, "Project directory is required"),
@@ -83,7 +83,7 @@ export default function TemplatesListPage() {
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema as any),
     defaultValues: {
-      projectName: "",
+      projectRepositoryName: "",
       template: "",
       directory: "",
     },
@@ -118,7 +118,7 @@ export default function TemplatesListPage() {
   const onSubmit = useCallback(
     (values: FormValues) => {
       router.push(
-        `/projects/instantiate-template/?projectName=${values.projectName}&template=${values.template}&selectedProjectDirectoryId=${values.directory}`,
+        `/projects/instantiate-template/?projectRepositoryName=${values.projectRepositoryName}&template=${values.template}&selectedProjectDirectoryId=${values.directory}`,
       );
       setOpen(false);
       form.reset();
@@ -150,12 +150,12 @@ export default function TemplatesListPage() {
             >
               <FormField
                 control={form.control}
-                name="projectName"
+                name="projectRepositoryName"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Project Name</FormLabel>
+                    <FormLabel>Project Repository Name</FormLabel>
                     <FormControl>
-                      <Input placeholder="My Awesome Project" {...field} />
+                      <Input placeholder="my-awesome-project" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -246,7 +246,7 @@ export default function TemplatesListPage() {
       caption="A list of your projects."
       buttons={createProjectDialog}
       onClick={(item) => {
-        router.push(`/projects/project?projectName=${item.name}`);
+        router.push(`/projects/project?projectRepositoryName=${item.name}`);
       }}
     />
   );

--- a/apps/web/src/app/(with-sidebar)/projects/project-staged-changes/page.tsx
+++ b/apps/web/src/app/(with-sidebar)/projects/project-staged-changes/page.tsx
@@ -16,28 +16,28 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 export default function ProjectStagedChangesPage() {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const projectNameParam = useMemo(
-    () => searchParams.get("projectName"),
+  const projectRepositoryNameParam = useMemo(
+    () => searchParams.get("projectRepositoryName"),
     [searchParams],
   );
   const [projectDiff, setProjectDiff] = useState<ParsedFile[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    if (!projectNameParam) {
+    if (!projectRepositoryNameParam) {
       toastNullError({
-        shortMessage: "No project name provided in search params.",
+        shortMessage: "No project repository name provided in search params.",
       });
       router.push("/projects");
       return;
     }
 
-    resolveConflictsAndDiff(projectNameParam).then(
+    resolveConflictsAndDiff(projectRepositoryNameParam).then(
       (data: Result<ParsedFile[] | null>) => {
         const toastResult = toastNullError({
           result: data,
           shortMessage: "Error retrieving project diff",
-          nullErrorMessage: `Project diff not found for ${projectNameParam}`,
+          nullErrorMessage: `Project diff not found for ${projectRepositoryNameParam}`,
           nullRedirectPath: "/projects",
         });
         if (!toastResult) {
@@ -46,15 +46,15 @@ export default function ProjectStagedChangesPage() {
         setProjectDiff(toastResult);
       },
     );
-  }, [projectNameParam, router]);
+  }, [projectRepositoryNameParam, router]);
 
   const handleCommit = useCallback(
     async (message: string) => {
-      if (!projectNameParam) return;
+      if (!projectRepositoryNameParam) return;
 
       setIsLoading(true);
       try {
-        const result = await commitChanges(projectNameParam, message);
+        const result = await commitChanges(projectRepositoryNameParam, message);
 
         const toastResult = toastNullError({
           result,
@@ -64,7 +64,7 @@ export default function ProjectStagedChangesPage() {
           return;
         }
 
-        router.push(`/projects/project/?projectName=${projectNameParam}`);
+        router.push(`/projects/project/?projectRepositoryName=${projectRepositoryNameParam}`);
       } catch (error) {
         toastNullError({
           error,
@@ -74,21 +74,21 @@ export default function ProjectStagedChangesPage() {
         setIsLoading(false);
       }
     },
-    [projectNameParam, router],
+    [projectRepositoryNameParam, router],
   );
 
   const handleCancel = useCallback(() => { }, []);
 
   const handleBack = useCallback(() => {
-    if (projectNameParam) {
-      router.push(`/projects/project/?projectName=${projectNameParam}`);
+    if (projectRepositoryNameParam) {
+      router.push(`/projects/project/?projectRepositoryName=${projectRepositoryNameParam}`);
     } else {
       router.push("/projects");
     }
-  }, [projectNameParam, router]);
+  }, [projectRepositoryNameParam, router]);
 
-  if (!projectNameParam) {
-    return <div>Error: No project name provided.</div>;
+  if (!projectRepositoryNameParam) {
+    return <div>Error: No project repository name provided.</div>;
   }
 
   if (!projectDiff || isLoading) {
@@ -107,7 +107,7 @@ export default function ProjectStagedChangesPage() {
           >
             <ArrowLeft className="h-5 w-5" />
           </Button>
-          <h1 className="text-xl font-semibold truncate">{projectNameParam}</h1>
+          <h1 className="text-xl font-semibold truncate">{projectRepositoryNameParam}</h1>
         </div>
         <div className="flex items-center gap-2">
           <CommitButton onCommit={handleCommit} onCancel={handleCancel} />
@@ -116,7 +116,7 @@ export default function ProjectStagedChangesPage() {
 
       <div className="flex-1 p-4">
         <DiffVisualizerPage
-          projectName={projectNameParam}
+          projectRepositoryName={projectRepositoryNameParam}
           parsedDiff={projectDiff}
         />
       </div>

--- a/apps/web/src/app/(with-sidebar)/projects/project-template-diff/page.tsx
+++ b/apps/web/src/app/(with-sidebar)/projects/project-template-diff/page.tsx
@@ -14,27 +14,27 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 export default function ProjectStagedChangesPage() {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const projectNameParam = useMemo(
-    () => searchParams.get("projectName"),
+  const projectRepositoryNameParam = useMemo(
+    () => searchParams.get("projectRepositoryName"),
     [searchParams],
   );
   const [projectDiff, setProjectDiff] = useState<ParsedFile[]>([]);
 
   useEffect(() => {
-    if (!projectNameParam) {
+    if (!projectRepositoryNameParam) {
       toastNullError({
-        shortMessage: "No project name provided in search params.",
+        shortMessage: "No project repository name provided in search params.",
       });
       router.push("/projects");
       return;
     }
 
-    diffProjectFromItsTemplate(projectNameParam).then(
+    diffProjectFromItsTemplate(projectRepositoryNameParam).then(
       (diffResult: Result<ParsedFile[]>) => {
         const diff = toastNullError({
           result: diffResult,
           shortMessage: "Error retrieving project diff",
-          nullErrorMessage: `Project diff not found for ${projectNameParam}`,
+          nullErrorMessage: `Project diff not found for ${projectRepositoryNameParam}`,
           nullRedirectPath: "/projects",
         });
 
@@ -52,18 +52,18 @@ export default function ProjectStagedChangesPage() {
         setProjectDiff(diff);
       },
     );
-  }, [projectNameParam, router]);
+  }, [projectRepositoryNameParam, router]);
 
   const handleBack = useCallback(() => {
-    if (projectNameParam) {
-      router.push(`/projects/project/?projectName=${projectNameParam}`);
+    if (projectRepositoryNameParam) {
+      router.push(`/projects/project/?projectRepositoryName=${projectRepositoryNameParam}`);
     } else {
       router.push("/projects");
     }
-  }, [projectNameParam, router]);
+  }, [projectRepositoryNameParam, router]);
 
-  if (!projectNameParam) {
-    return <div>Error: No project name provided.</div>;
+  if (!projectRepositoryNameParam) {
+    return <div>Error: No project repository name provided.</div>;
   }
 
   if (!projectDiff) {
@@ -82,13 +82,13 @@ export default function ProjectStagedChangesPage() {
           >
             <ArrowLeft className="h-5 w-5" />
           </Button>
-          <h1 className="text-xl font-semibold truncate">{projectNameParam}</h1>
+          <h1 className="text-xl font-semibold truncate">{projectRepositoryNameParam}</h1>
         </div>
       </div>
 
       <div className="flex-1 p-4">
         <DiffVisualizerPage
-          projectName={projectNameParam}
+          projectRepositoryName={projectRepositoryNameParam}
           parsedDiff={projectDiff}
         />
       </div>

--- a/apps/web/src/app/(with-sidebar)/projects/project/page.tsx
+++ b/apps/web/src/app/(with-sidebar)/projects/project/page.tsx
@@ -205,8 +205,8 @@ const buildProjectTree = (
 export default function ProjectTemplateTreePage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const projectNameParam = useMemo(
-    () => searchParams.get("projectName"),
+  const projectRepositoryNameParam = useMemo(
+    () => searchParams.get("projectRepositoryName"),
     [searchParams],
   );
   const [project, setProject] = useState<ProjectDTO>();
@@ -219,9 +219,9 @@ export default function ProjectTemplateTreePage() {
 
   // Fetch project data.
   useEffect(() => {
-    if (!projectNameParam) {
+    if (!projectRepositoryNameParam) {
       toastNullError({
-        shortMessage: "No project name provided in search params.",
+        shortMessage: "No project repository name provided in search params.",
       });
       router.push("/projects");
       return;
@@ -229,8 +229,8 @@ export default function ProjectTemplateTreePage() {
 
     const retrieveStuff = async () => {
       const [projectResult, revisionResult] = await Promise.all([
-        retrieveProject(projectNameParam),
-        retrieveTemplateRevisionForProject(projectNameParam),
+        retrieveProject(projectRepositoryNameParam),
+        retrieveTemplateRevisionForProject(projectRepositoryNameParam),
       ]);
 
       const project = toastNullError({
@@ -256,7 +256,7 @@ export default function ProjectTemplateTreePage() {
       const revision = toastNullError({
         result: revisionResult,
         shortMessage: "Error retrieving template revision.",
-        nullErrorMessage: `Template not found for project ${projectNameParam}.`,
+        nullErrorMessage: `Template not found for project ${projectRepositoryNameParam}.`,
         nullRedirectPath: "/projects",
         router,
       });
@@ -268,7 +268,7 @@ export default function ProjectTemplateTreePage() {
       setRootTemplate(revision);
     };
     retrieveStuff();
-  }, [projectNameParam, router]);
+  }, [projectRepositoryNameParam, router]);
 
   useEffect(() => {
     if (rootTemplate) {
@@ -306,9 +306,9 @@ export default function ProjectTemplateTreePage() {
 
   const handleBranchChange = useCallback(
     async (branch: string) => {
-      if (!projectNameParam) return;
+      if (!projectRepositoryNameParam) return;
 
-      const switchResult = await switchProjectBranch(projectNameParam, branch);
+      const switchResult = await switchProjectBranch(projectRepositoryNameParam, branch);
       const result = toastNullError({
         result: switchResult,
         shortMessage: "Error switching branch.",
@@ -316,18 +316,18 @@ export default function ProjectTemplateTreePage() {
       if (!result) {
         return;
       }
-      const updatedProjectResult = await retrieveProject(projectNameParam);
+      const updatedProjectResult = await retrieveProject(projectRepositoryNameParam);
       const updatedProject = toastNullError({
         result: updatedProjectResult,
         shortMessage: "Error retrieving updated project.",
-        nullErrorMessage: `Updated project not found for ${projectNameParam}.`,
+        nullErrorMessage: `Updated project not found for ${projectRepositoryNameParam}.`,
       });
       if (!updatedProject) {
         return;
       }
       setProject(updatedProject);
     },
-    [projectNameParam],
+    [projectRepositoryNameParam],
   );
 
   if (!project || !rootTemplate || !latestTemplate) {
@@ -340,7 +340,7 @@ export default function ProjectTemplateTreePage() {
 
   return (
     <div className="flex flex-col h-screen">
-      {projectNameParam && (
+      {projectRepositoryNameParam && (
         <ProjectHeader
           project={project}
           onBranchChange={handleBranchChange}

--- a/apps/web/src/app/actions/git.ts
+++ b/apps/web/src/app/actions/git.ts
@@ -5,50 +5,50 @@ import * as tempLib from "@timonteutelink/skaff-lib";
 import { ParsedFile, Result } from "@timonteutelink/skaff-lib";
 
 export async function commitChanges(
-  projectName: string,
+  projectRepositoryName: string,
   commitMessage: string,
 ): Promise<Result<void>> {
-  const project = await findProject(projectName);
+  const project = await findProject(projectRepositoryName);
 
   if ('error' in project) {
     return { error: project.error };
   }
 
   if (!project.data) {
-    return { error: `Project ${projectName} not found.` };
+    return { error: `Project ${projectRepositoryName} not found.` };
   }
 
   return await tempLib.addAllAndCommit(project.data, commitMessage);
 }
 
 export async function switchProjectBranch(
-  projectName: string,
+  projectRepositoryName: string,
   branch: string,
 ): Promise<Result<void>> {
-  const project = await findProject(projectName);
+  const project = await findProject(projectRepositoryName);
 
   if ('error' in project) {
     return { error: project.error };
   }
 
   if (!project.data) {
-    return { error: `Project ${projectName} not found.` };
+    return { error: `Project ${projectRepositoryName} not found.` };
   }
 
   return await tempLib.switchProjectBranch(project.data, branch);
 }
 
 export async function diffProjectFromItsTemplate(
-  projectName: string,
+  projectRepositoryName: string,
 ): Promise<Result<ParsedFile[]>> {
-  const project = await findProject(projectName);
+  const project = await findProject(projectRepositoryName);
 
   if ('error' in project) {
     return { error: project.error };
   }
 
   if (!project.data) {
-    return { error: `Project ${projectName} not found.` };
+    return { error: `Project ${projectRepositoryName} not found.` };
   }
 
   const result = await tempLib.diffProjectFromTemplate(project.data);

--- a/apps/web/src/app/actions/instantiate.ts
+++ b/apps/web/src/app/actions/instantiate.ts
@@ -5,7 +5,7 @@ import { getConfig, NewTemplateDiffResult, ParsedFile, ProjectCreationResult, pr
 import { UserTemplateSettings } from "@timonteutelink/template-types-lib";
 
 export async function createNewProject(
-  projectName: string,
+  projectRepositoryName: string,
   templateName: string,
   projectDirPathId: string,
   userTemplateSettings: UserTemplateSettings,
@@ -22,22 +22,22 @@ export async function createNewProject(
     };
   }
 
-  return await tempLib.generateNewProject(projectName, templateName, projectDirPath, userTemplateSettings, { git: true });
+  return await tempLib.generateNewProject(projectRepositoryName, templateName, projectDirPath, userTemplateSettings, { git: true });
 }
 
 export async function prepareTemplateModificationDiff(
   userTemplateSettings: UserTemplateSettings,
-  destinationProjectName: string,
+  destinationProjectRepositoryName: string,
   templateInstanceId: string,
 ): Promise<Result<NewTemplateDiffResult>> {
-  const destinationProject = await findProject(destinationProjectName);
+  const destinationProject = await findProject(destinationProjectRepositoryName);
 
   if ('error' in destinationProject) {
     return { error: destinationProject.error };
   }
 
   if (!destinationProject.data) {
-    return { error: `Project ${destinationProjectName} not found.` };
+    return { error: `Project ${destinationProjectRepositoryName} not found.` };
   }
 
   return await tempLib.prepareModificationDiff(userTemplateSettings, destinationProject.data, templateInstanceId);
@@ -47,17 +47,17 @@ export async function prepareTemplateInstantiationDiff(
   rootTemplateName: string,
   templateName: string,
   parentInstanceId: string,
-  destinationProjectName: string,
+  destinationProjectRepositoryName: string,
   userTemplateSettings: UserTemplateSettings,
 ): Promise<Result<NewTemplateDiffResult>> {
-  const destinationProject = await findProject(destinationProjectName);
+  const destinationProject = await findProject(destinationProjectRepositoryName);
 
   if ('error' in destinationProject) {
     return { error: destinationProject.error };
   }
 
   if (!destinationProject.data) {
-    return { error: `Project ${destinationProjectName} not found.` };
+    return { error: `Project ${destinationProjectRepositoryName} not found.` };
   }
 
   return await tempLib.prepareInstantiationDiff(
@@ -70,84 +70,84 @@ export async function prepareTemplateInstantiationDiff(
 }
 
 export async function resolveConflictsAndDiff(
-  projectName: string,
+  projectRepositoryName: string,
 ): Promise<Result<ParsedFile[]>> {
-  const project = await findProject(projectName);
+  const project = await findProject(projectRepositoryName);
 
   if ('error' in project) {
     return { error: project.error };
   }
 
   if (!project.data) {
-    return { error: `Project ${projectName} not found.` };
+    return { error: `Project ${projectRepositoryName} not found.` };
   }
 
   return await tempLib.addAllAndDiff(project.data);
 }
 
 export async function restoreAllChangesToCleanProject(
-  projectName: string,
+  projectRepositoryName: string,
 ): Promise<Result<void>> {
-  const project = await findProject(projectName);
+  const project = await findProject(projectRepositoryName);
 
   if ('error' in project) {
     return { error: project.error };
   }
 
   if (!project.data) {
-    return { error: `Project ${projectName} not found.` };
+    return { error: `Project ${projectRepositoryName} not found.` };
   }
 
   return await tempLib.restoreAllChanges(project.data);
 }
 
 export async function applyTemplateDiffToProject(
-  projectName: string,
+  projectRepositoryName: string,
   diffHash: string,
 ): Promise<Result<ParsedFile[] | { resolveBeforeContinuing: boolean }>> {
-  const project = await findProject(projectName);
+  const project = await findProject(projectRepositoryName);
 
   if ('error' in project) {
     return { error: project.error };
   }
 
   if (!project.data) {
-    return { error: `Project ${projectName} not found.` };
+    return { error: `Project ${projectRepositoryName} not found.` };
   }
 
   return await tempLib.applyDiff(project.data, diffHash);
 }
 
 export async function cancelProjectCreation(
-  projectName: string,
+  projectRepositoryName: string,
 ): Promise<Result<void>> {
-  const project = await findProject(projectName);
+  const project = await findProject(projectRepositoryName);
 
   if ('error' in project) {
     return { error: project.error };
   }
 
   if (!project.data) {
-    return { error: `Project ${projectName} not found.` };
+    return { error: `Project ${projectRepositoryName} not found.` };
   }
 
   return await tempLib.deleteProject(project.data);
 }
 
 export async function generateNewProjectFromExisting(
-  currentProjectName: string,
+  currentProjectRepositoryName: string,
   newProjectDestinationDirPathId: string,
-  newProjectName: string,
+  newProjectRepositoryName: string,
 ): Promise<Result<ProjectCreationResult>> {
   const config = await getConfig();
-  const currentProject = await findProject(currentProjectName);
+  const currentProject = await findProject(currentProjectRepositoryName);
 
   if ('error' in currentProject) {
     return { error: currentProject.error };
   }
 
   if (!currentProject.data) {
-    return { error: `Project ${currentProjectName} not found.` };
+    return { error: `Project ${currentProjectRepositoryName} not found.` };
   }
 
   const newProjectDestinationDirPath = config.PROJECT_SEARCH_PATHS.find(
@@ -162,23 +162,23 @@ export async function generateNewProjectFromExisting(
   return await tempLib.generateNewProjectFromExisting(
     currentProject.data,
     newProjectDestinationDirPath,
-    newProjectName,
+    newProjectRepositoryName,
     { git: true }
   );
 }
 
 export async function retrieveDiffUpdateProjectNewTemplateRevision(
-  projectName: string,
+  projectRepositoryName: string,
   newTemplateRevisionCommitHash: string,
 ): Promise<Result<NewTemplateDiffResult>> {
-  const project = await findProject(projectName);
+  const project = await findProject(projectRepositoryName);
 
   if ('error' in project) {
     return { error: project.error };
   }
 
   if (!project.data) {
-    return { error: `Project ${projectName} not found.` };
+    return { error: `Project ${projectRepositoryName} not found.` };
   }
 
   return await tempLib.prepareUpdateDiff(
@@ -190,7 +190,7 @@ export async function retrieveDiffUpdateProjectNewTemplateRevision(
 export async function generateProjectFromProjectSettings(
   projectSettingsJson: string,
   projectDirPathId: string,
-  newProjectDirName: string,
+  newProjectRepositoryDirName: string,
 ): Promise<Result<ProjectCreationResult>> {
   const config = await getConfig();
   const projectDirPath = config.PROJECT_SEARCH_PATHS.find(
@@ -206,7 +206,7 @@ export async function generateProjectFromProjectSettings(
   return await tempLib.generateNewProjectFromSettings(
     projectSettingsJson,
     projectDirPath,
-    newProjectDirName,
+    newProjectRepositoryDirName,
     { git: true }
   );
 }

--- a/apps/web/src/app/actions/project.ts
+++ b/apps/web/src/app/actions/project.ts
@@ -39,9 +39,9 @@ export async function retrieveProjects(): Promise<Result<ProjectDTO[]>> {
 }
 
 export async function retrieveProject(
-  projectName: string,
+  projectRepositoryName: string,
 ): Promise<Result<ProjectDTO | null>> {
-  const project = await findProject(projectName);
+  const project = await findProject(projectRepositoryName);
   if ("error" in project) {
     return { error: project.error };
   }
@@ -56,18 +56,18 @@ export async function retrieveProject(
 }
 
 export async function runProjectCommand(
-  projectName: string,
+  projectRepositoryName: string,
   templateInstanceId: string,
   commandTitle: string,
 ): Promise<Result<string>> {
-  const project = await findProject(projectName);
+  const project = await findProject(projectRepositoryName);
 
   if ('error' in project) {
     return { error: project.error };
   }
 
   if (!project.data) {
-    return { error: `Project ${projectName} not found.` };
+    return { error: `Project ${projectRepositoryName} not found.` };
   }
 
   return await project.data.executeTemplateCommand(

--- a/apps/web/src/app/actions/template.ts
+++ b/apps/web/src/app/actions/template.ts
@@ -94,16 +94,16 @@ export async function retrieveAllTemplateRevisions(
 }
 
 export async function retrieveTemplateRevisionForProject(
-  projectName: string,
+  projectRepositoryName: string,
 ): Promise<Result<TemplateDTO | null>> {
-  const project = await findProject(projectName);
+  const project = await findProject(projectRepositoryName);
 
   if ('error' in project) {
     return { error: project.error };
   }
 
   if (!project.data) {
-    return { error: `Project ${projectName} not found.` };
+    return { error: `Project ${projectRepositoryName} not found.` };
   }
 
   const result = await tempLib.loadProjectTemplateRevision(project.data);

--- a/apps/web/src/app/projects/instantiate-template/page.tsx
+++ b/apps/web/src/app/projects/instantiate-template/page.tsx
@@ -46,8 +46,8 @@ import { ConfirmationDialog } from "@/components/general/confirmation-dialog";
 const TemplateInstantiationPage: React.FC = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const projectNameParam = useMemo(
-    () => searchParams.get("projectName"),
+  const projectRepositoryNameParam = useMemo(
+    () => searchParams.get("projectRepositoryName"),
     [searchParams],
   );
   const templateNameParam = useMemo(
@@ -80,9 +80,9 @@ const TemplateInstantiationPage: React.FC = () => {
     useState<UserTemplateSettings | null>(null);
 
   useEffect(() => {
-    if (!projectNameParam) {
+    if (!projectRepositoryNameParam) {
       toastNullError({
-        shortMessage: "Project name not provided in search params.",
+        shortMessage: "Project repository name not provided in search params.",
       });
       router.push("/projects");
       return;
@@ -115,10 +115,10 @@ const TemplateInstantiationPage: React.FC = () => {
     }
     const retrieveStuff = async () => {
       const [projectResult, revisionResult] = await Promise.all([
-        retrieveProject(projectNameParam),
+        retrieveProject(projectRepositoryNameParam),
         selectedDirectoryIdParam
           ? retrieveTemplate(templateNameParam!)
-          : retrieveTemplateRevisionForProject(projectNameParam),
+          : retrieveTemplateRevisionForProject(projectRepositoryNameParam),
       ]);
 
       const revision = toastNullError({
@@ -126,7 +126,7 @@ const TemplateInstantiationPage: React.FC = () => {
           TemplateSummary | TemplateDTO | null
         >,
         shortMessage: "Error retrieving template.",
-        nullErrorMessage: `Template not found for project: ${projectNameParam}`,
+        nullErrorMessage: `Template not found for project: ${projectRepositoryNameParam}`,
         nullRedirectPath: "/projects",
         router,
       });
@@ -156,7 +156,7 @@ const TemplateInstantiationPage: React.FC = () => {
       if (!project) {
         if (!selectedDirectoryIdParam) {
           toastNullError({
-            shortMessage: `Project not found: ${projectNameParam}`,
+            shortMessage: `Project not found: ${projectRepositoryNameParam}`,
           });
           router.push("/projects");
         }
@@ -177,7 +177,7 @@ const TemplateInstantiationPage: React.FC = () => {
       }
       const newRevisionResult =
         await retrieveDiffUpdateProjectNewTemplateRevision(
-          projectNameParam,
+          projectRepositoryNameParam,
           newRevisionHashParam,
         );
       const newRevision = toastNullError({
@@ -191,7 +191,7 @@ const TemplateInstantiationPage: React.FC = () => {
     };
     retrieveStuff();
   }, [
-    projectNameParam,
+    projectRepositoryNameParam,
     router,
     templateNameParam,
     parentTemplateInstanceIdParam,
@@ -210,13 +210,13 @@ const TemplateInstantiationPage: React.FC = () => {
   const handleSubmitSettings = useCallback(
     async (data: UserTemplateSettings) => {
       if (
-        !projectNameParam ||
+        !projectRepositoryNameParam ||
         !templateNameParam ||
         !rootTemplate ||
         !subTemplate
       ) {
         toastNullError({
-          shortMessage: "Project name or template name not found.",
+          shortMessage: "Project repository name or template name not found.",
         });
         return;
       }
@@ -224,7 +224,7 @@ const TemplateInstantiationPage: React.FC = () => {
       setStoredFormData(data);
       if (selectedDirectoryIdParam) {
         const newProjectResult = await createNewProject(
-          projectNameParam,
+          projectRepositoryNameParam,
           templateNameParam,
           selectedDirectoryIdParam,
           data,
@@ -248,9 +248,9 @@ const TemplateInstantiationPage: React.FC = () => {
           return;
         }
 
-        if (project.settings.projectName !== projectNameParam) {
+        if (project.settings.projectRepositoryName !== projectRepositoryNameParam) {
           toastNullError({
-            shortMessage: "Project name does not match.",
+            shortMessage: "Project repository name does not match.",
           });
           return;
         }
@@ -281,7 +281,7 @@ const TemplateInstantiationPage: React.FC = () => {
             rootTemplate.config.templateConfig.name,
             subTemplateValue.config.templateConfig.name,
             parentTemplateInstanceIdParam!,
-            projectNameParam,
+            projectRepositoryNameParam,
             data,
           );
 
@@ -298,14 +298,14 @@ const TemplateInstantiationPage: React.FC = () => {
       } else if (existingTemplateInstanceIdParam) {
         if (!project) {
           toastNullError({
-            shortMessage: `Project not found: ${projectNameParam}`,
+            shortMessage: `Project not found: ${projectRepositoryNameParam}`,
           });
           return;
         }
 
-        if (project.settings.projectName !== projectNameParam) {
+        if (project.settings.projectRepositoryName !== projectRepositoryNameParam) {
           toastNullError({
-            shortMessage: "Project name does not match.",
+            shortMessage: "Project repository name does not match.",
           });
           return;
         }
@@ -322,7 +322,7 @@ const TemplateInstantiationPage: React.FC = () => {
         const templateModificationResult =
           await prepareTemplateModificationDiff(
             data,
-            projectNameParam,
+            projectRepositoryNameParam,
             existingTemplateInstanceIdParam,
           );
 
@@ -344,7 +344,7 @@ const TemplateInstantiationPage: React.FC = () => {
       }
     },
     [
-      projectNameParam,
+      projectRepositoryNameParam,
       rootTemplate,
       subTemplate,
       parentTemplateInstanceIdParam,
@@ -357,9 +357,9 @@ const TemplateInstantiationPage: React.FC = () => {
 
   const handleConfirmAppliedDiff = useCallback(
     async (commitMessage: string) => {
-      if (!projectNameParam || !commitMessage) {
+      if (!projectRepositoryNameParam || !commitMessage) {
         toastNullError({
-          shortMessage: "Project name or commit message not found.",
+          shortMessage: "Project repository name or commit message not found.",
         });
         return;
       }
@@ -370,7 +370,7 @@ const TemplateInstantiationPage: React.FC = () => {
         return;
       }
 
-      const commitResult = await commitChanges(projectNameParam, commitMessage);
+      const commitResult = await commitChanges(projectRepositoryNameParam, commitMessage);
 
       const commit = toastNullError({
         result: commitResult,
@@ -380,9 +380,9 @@ const TemplateInstantiationPage: React.FC = () => {
       if (commit === false) {
         return;
       }
-      router.push(`/projects/project/?projectName=${projectNameParam}`);
+      router.push(`/projects/project/?projectRepositoryName=${projectRepositoryNameParam}`);
     },
-    [router, projectNameParam],
+    [router, projectRepositoryNameParam],
   );
 
   const handleUploadProjectSettings = useCallback(
@@ -390,11 +390,11 @@ const TemplateInstantiationPage: React.FC = () => {
       if (
         !templateNameParam ||
         !selectedDirectoryIdParam ||
-        !projectNameParam
+        !projectRepositoryNameParam
       ) {
         toastNullError({
           shortMessage:
-            "Not creating a project. 'template' or 'selectedDirectoryId' or 'projectName' is missing.",
+            "Not creating a project. 'template' or 'selectedDirectoryId' or 'projectRepositoryName' is missing.",
         });
         return { data: undefined };
       }
@@ -427,7 +427,7 @@ const TemplateInstantiationPage: React.FC = () => {
       const newProjectResult = await generateProjectFromProjectSettings(
         projectSettingsJson.text,
         selectedDirectoryIdParam,
-        projectNameParam,
+        projectRepositoryNameParam,
       );
 
       const newProject = toastNullError({
@@ -442,13 +442,13 @@ const TemplateInstantiationPage: React.FC = () => {
       setAppliedDiff(newProject.diff || null);
       return { data: undefined };
     },
-    [projectNameParam, selectedDirectoryIdParam, templateNameParam],
+    [projectRepositoryNameParam, selectedDirectoryIdParam, templateNameParam],
   );
 
   const handleSubmitDiffToApply = useCallback(async () => {
-    if (!projectNameParam) {
+    if (!projectRepositoryNameParam) {
       toastNullError({
-        shortMessage: "Project name not found.",
+        shortMessage: "Project repository name not found.",
       });
       return;
     }
@@ -466,7 +466,7 @@ const TemplateInstantiationPage: React.FC = () => {
     }
 
     const applyDiffResult = await applyTemplateDiffToProject(
-      projectNameParam,
+      projectRepositoryNameParam,
       diffToApply.diffHash,
     );
 
@@ -488,7 +488,7 @@ const TemplateInstantiationPage: React.FC = () => {
         return;
       }
 
-      const resolveResult = await resolveConflictsAndDiff(projectNameParam);
+      const resolveResult = await resolveConflictsAndDiff(projectRepositoryNameParam);
 
       const resolved = toastNullError({
         result: resolveResult,
@@ -505,19 +505,19 @@ const TemplateInstantiationPage: React.FC = () => {
     }
 
     setAppliedDiff(diff);
-  }, [projectNameParam, diffToApply, selectedDirectoryIdParam]);
+  }, [projectRepositoryNameParam, diffToApply, selectedDirectoryIdParam]);
 
   const handleBackFromAppliedDiff = useCallback(async () => {
-    if (!projectNameParam) {
+    if (!projectRepositoryNameParam) {
       toastNullError({
-        shortMessage: "Project name not found.",
+        shortMessage: "Project repository name not found.",
       });
       return;
     }
 
     if (selectedDirectoryIdParam) {
       // when going back just delete project that was created. Then recreate again when going to diff. For projects this is an easy workflow for templates will be another step after viewing the diff. and no changes will be applied to project when showing first diff so when going back from first diff no deletion is necessary.
-      const result = await cancelProjectCreation(projectNameParam);
+      const result = await cancelProjectCreation(projectRepositoryNameParam);
 
       const cancel = toastNullError({
         result: result,
@@ -528,7 +528,7 @@ const TemplateInstantiationPage: React.FC = () => {
       }
     } else {
       const restoreResult =
-        await restoreAllChangesToCleanProject(projectNameParam);
+        await restoreAllChangesToCleanProject(projectRepositoryNameParam);
       const restored = toastNullError({
         result: restoreResult,
         shortMessage: "Error restoring changes.",
@@ -539,7 +539,7 @@ const TemplateInstantiationPage: React.FC = () => {
     }
 
     setAppliedDiff(null);
-  }, [projectNameParam, selectedDirectoryIdParam]);
+  }, [projectRepositoryNameParam, selectedDirectoryIdParam]);
 
   const handleBackFromDiffToApply = useCallback(() => {
     setDiffToApply(null);
@@ -570,11 +570,11 @@ const TemplateInstantiationPage: React.FC = () => {
     return instantiatedSettings;
   }, [subTemplate, project, existingTemplateInstanceIdParam, storedFormData]);
 
-  if (!projectNameParam) {
+  if (!projectRepositoryNameParam) {
     return (
       <div className="container mx-auto py-10">
         <h1 className="text-2xl font-bold">
-          Project name not provided in search params.
+          Project repository name not provided in search params.
         </h1>
       </div>
     );
@@ -599,7 +599,7 @@ const TemplateInstantiationPage: React.FC = () => {
       <div className="container py-4 mx-auto">
         <h1 className="text-2xl font-bold mb-4">Diff to apply</h1>
         <DiffVisualizerPage
-          projectName={projectNameParam}
+          projectRepositoryName={projectRepositoryNameParam}
           parsedDiff={appliedDiff}
         />
         <div className="flex justify-between mt-4">
@@ -633,7 +633,7 @@ const TemplateInstantiationPage: React.FC = () => {
       <div className="container py-4 mx-auto">
         <h1 className="text-2xl font-bold mb-4">Diff to apply</h1>
         <DiffVisualizerPage
-          projectName={projectNameParam}
+          projectRepositoryName={projectRepositoryNameParam}
           parsedDiff={diffToApply.parsedDiff}
         />
         <div className="flex flex-row-reverse justify-between mt-4">
@@ -700,7 +700,7 @@ const TemplateInstantiationPage: React.FC = () => {
         </div>
       ) : null}
       <TemplateSettingsForm
-        projectName={projectNameParam}
+        projectRepositoryName={projectRepositoryNameParam}
         selectedTemplate={templateNameParam}
         selectedTemplateSettingsSchema={
           subTemplate.data.config.templateSettingsSchema
@@ -709,7 +709,7 @@ const TemplateInstantiationPage: React.FC = () => {
         action={handleSubmitSettings}
         cancel={() => {
           router.push(
-            `/projects/${projectNameParam && !selectedDirectoryIdParam ? `project/?projectName=${projectNameParam}` : ""}`,
+            `/projects/${projectRepositoryNameParam && !selectedDirectoryIdParam ? `project/?projectRepositoryName=${projectRepositoryNameParam}` : ""}`,
           );
         }}
       />

--- a/apps/web/src/components/general/git/diff-visualizer-page.tsx
+++ b/apps/web/src/components/general/git/diff-visualizer-page.tsx
@@ -5,12 +5,12 @@ import { FileTree } from "./file-tree";
 import { DiffVisualizer } from "./diff-visualizer";
 
 interface DiffVisualizerPageProps {
-  projectName: string;
+  projectRepositoryName: string;
   parsedDiff: ParsedFile[];
 }
 
 export const DiffVisualizerPage: React.FC<DiffVisualizerPageProps> = ({
-  projectName,
+  projectRepositoryName,
   parsedDiff,
 }) => {
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
@@ -34,7 +34,7 @@ export const DiffVisualizerPage: React.FC<DiffVisualizerPageProps> = ({
     <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
       <div className="md:col-span-1">
         <FileTree
-          projectName={projectName}
+          projectRepositoryName={projectRepositoryName}
           files={parsedDiff}
           selectedFile={selectedFile}
           onSelectFile={setSelectedFile}

--- a/apps/web/src/components/general/git/file-tree.tsx
+++ b/apps/web/src/components/general/git/file-tree.tsx
@@ -17,21 +17,21 @@ import { Badge } from "@/components/ui/badge";
 import { ParsedFile } from "@timonteutelink/skaff-lib/browser";
 
 interface FileTreeProps {
-  projectName: string;
+  projectRepositoryName: string;
   files: ParsedFile[];
   selectedFile: string | null;
   onSelectFile: (path: string) => void;
 }
 
 export function FileTree({
-  projectName,
+  projectRepositoryName,
   files,
   selectedFile,
   onSelectFile,
 }: FileTreeProps) {
   const fileTree = useMemo(
-    () => buildFileTree(projectName, files),
-    [files, projectName],
+    () => buildFileTree(projectRepositoryName, files),
+    [files, projectRepositoryName],
   );
 
   return (
@@ -173,9 +173,9 @@ function StatusBadge({ status }: { status: "added" | "modified" | "deleted" }) {
 }
 
 // Helper function to build a file tree from a flat list of files
-function buildFileTree(projectName: string, files: ParsedFile[]): TreeNode {
+function buildFileTree(projectRepositoryName: string, files: ParsedFile[]): TreeNode {
   const root: TreeNode = {
-    name: projectName,
+    name: projectRepositoryName,
     path: "",
     type: "directory",
     children: [],

--- a/apps/web/src/components/general/projects/project-details-panel.tsx
+++ b/apps/web/src/components/general/projects/project-details-panel.tsx
@@ -115,7 +115,7 @@ export function ProjectDetailsPanel({
                 disabled={!project?.name}
                 onClick={() => {
                   router.push(
-                    `/projects/instantiate-template/?projectName=${project.name}` +
+                    `/projects/instantiate-template/?projectRepositoryName=${project.name}` +
                     `&existingTemplateInstanceId=${id}` +
                     `&template=${selectedInstantiatedTemplate.templateName}`,
                   );
@@ -275,7 +275,7 @@ export function ProjectDetailsPanel({
           disabled={!project || !project.name}
           onClick={() => {
             router.push(
-              `/projects/instantiate-template/?projectName=${project.name}` +
+              `/projects/instantiate-template/?projectRepositoryName=${project.name}` +
               `&template=${candidate.config.templateConfig.name}` +
               `&parentTemplateInstanceId=${selectedNode.parentId}`,
             );

--- a/apps/web/src/components/general/projects/project-header.tsx
+++ b/apps/web/src/components/general/projects/project-header.tsx
@@ -127,7 +127,7 @@ export function ProjectHeader({
           disabled={project.gitStatus!.isClean}
           onClick={() =>
             router.push(
-              `/projects/project-staged-changes?projectName=${project.name}`,
+              `/projects/project-staged-changes?projectRepositoryName=${project.name}`,
             )
           }
         >
@@ -141,7 +141,7 @@ export function ProjectHeader({
           disabled={isDiffClean}
           onClick={() =>
             router.push(
-              `/projects/project-template-diff?projectName=${project.name}`,
+              `/projects/project-template-diff?projectRepositoryName=${project.name}`,
             )
           }
         >
@@ -155,7 +155,7 @@ export function ProjectHeader({
           disabled={!project.outdatedTemplate}
           onClick={() =>
             router.push(
-              `/projects/instantiate-template/?projectName=${project.settings.projectName}&newRevisionHash=${latestTemplate.currentCommitHash}`,
+              `/projects/instantiate-template/?projectRepositoryName=${project.settings.projectRepositoryName}&newRevisionHash=${latestTemplate.currentCommitHash}`,
             )
           }
         >

--- a/apps/web/src/components/general/template-settings/template-settings-form.tsx
+++ b/apps/web/src/components/general/template-settings/template-settings-form.tsx
@@ -27,7 +27,7 @@ import { RecordFieldRenderer } from "./field-renderers/record-field-renderer";
 import { toastNullError } from "@/lib/utils";
 
 export const TemplateSettingsForm: React.FC<TemplateSettingsFormProps> = ({
-  projectName,
+  projectRepositoryName,
   selectedTemplate,
   selectedTemplateSettingsSchema,
   formDefaultValues,
@@ -284,7 +284,7 @@ export const TemplateSettingsForm: React.FC<TemplateSettingsFormProps> = ({
           <p className="text-muted-foreground">
             Configure settings for template{" "}
             <span className="font-medium">{selectedTemplate}</span> in project{" "}
-            <span className="font-medium">{projectName}</span>
+            <span className="font-medium">{projectRepositoryName}</span>
           </p>
         </div>
 

--- a/apps/web/src/components/general/template-settings/types.ts
+++ b/apps/web/src/components/general/template-settings/types.ts
@@ -4,7 +4,7 @@ import type { UseFormReturn } from "react-hook-form";
 import { ReactNode } from "react";
 
 export interface TemplateSettingsFormProps {
-  projectName: string;
+  projectRepositoryName: string;
   selectedTemplate: string;
   selectedTemplateSettingsSchema: any;
   formDefaultValues: Record<string, any>;

--- a/apps/web/src/lib/server-utils.ts
+++ b/apps/web/src/lib/server-utils.ts
@@ -7,14 +7,17 @@ import {
 } from "@timonteutelink/skaff-lib";
 
 export async function findProject(
-  projectName: string,
+  projectRepositoryName: string,
 ): Promise<Result<Project>> {
   const projectRepository = resolveProjectRepository();
   const config = await getConfig();
 
   let project: Project | null = null;
   for (const searchPath of config.PROJECT_SEARCH_PATHS) {
-    const result = await projectRepository.findProjectByName(searchPath, projectName);
+    const result = await projectRepository.findProjectByRepositoryName(
+      searchPath,
+      projectRepositoryName,
+    );
     if ("error" in result) {
       return { error: result.error };
     }
@@ -26,8 +29,8 @@ export async function findProject(
   }
 
   if (!project) {
-    backendLogger.error(`Project ${projectName} not found`);
-    return { error: `Project ${projectName} not found` };
+    backendLogger.error(`Project ${projectRepositoryName} not found`);
+    return { error: `Project ${projectRepositoryName} not found` };
   }
 
   return { data: project };

--- a/packages/docs/src/docs/guides/authoring/workflow.mdx
+++ b/packages/docs/src/docs/guides/authoring/workflow.mdx
@@ -37,7 +37,10 @@ import type {
 } from "@timonteutelink/template-types-lib";
 
 const templateSettingsSchema = z.object({
-  projectName: z.string().min(1).describe("NPM package name"),
+  projectRepositoryName: z
+    .string()
+    .min(1)
+    .describe("NPM package name"),
   includeAuth: z
     .boolean()
     .default(false)

--- a/packages/skaff-lib/src/actions/instantiate/generate-new-project-from-existing.ts
+++ b/packages/skaff-lib/src/actions/instantiate/generate-new-project-from-existing.ts
@@ -6,16 +6,19 @@ import { resolveProjectCreationManager } from "../../core/projects/ProjectCreati
 export async function generateNewProjectFromExisting(
   oldProject: Project,
   newProjectDestinationDirPath: string,
-  newProjectName: string,
+  newProjectRepositoryName: string,
   projectCreationOptions?: ProjectCreationOptions
 ): Promise<Result<ProjectCreationResult>> {
-  const newSettings = { ...oldProject.instantiatedProjectSettings, projectName: newProjectName };
+  const newSettings = {
+    ...oldProject.instantiatedProjectSettings,
+    projectRepositoryName: newProjectRepositoryName,
+  };
 
   const projectCreationManager = resolveProjectCreationManager();
 
   const result = await projectCreationManager.generateFromTemplateSettings(
     newSettings,
-    path.join(newProjectDestinationDirPath, newProjectName),
+    path.join(newProjectDestinationDirPath, newProjectRepositoryName),
     projectCreationOptions
   );
 

--- a/packages/skaff-lib/src/actions/instantiate/generate-new-project-from-settings.ts
+++ b/packages/skaff-lib/src/actions/instantiate/generate-new-project-from-settings.ts
@@ -11,7 +11,7 @@ import { ProjectSettings, projectSettingsSchema } from "@timonteutelink/template
 export async function generateNewProjectFromSettings(
   projectSettingsJson: string,
   newProjectDirPath: string,
-  newProjectDirName: string,
+  newProjectRepositoryDirName: string,
   projectCreationOptions?: ProjectCreationOptions,
 ): Promise<Result<ProjectCreationResult>> {
   let parsedProjectSettings: ProjectSettings | undefined;
@@ -28,13 +28,13 @@ export async function generateNewProjectFromSettings(
     return { error: `Failed to parse project settings.` };
   }
 
-  parsedProjectSettings.projectName = newProjectDirName;
+  parsedProjectSettings.projectRepositoryName = newProjectRepositoryDirName;
 
   const projectCreationManager = resolveProjectCreationManager();
 
   return await projectCreationManager.generateFromTemplateSettings(
     parsedProjectSettings,
-    path.join(newProjectDirPath, newProjectDirName),
+    path.join(newProjectDirPath, newProjectRepositoryDirName),
     projectCreationOptions
   );
 }

--- a/packages/skaff-lib/src/actions/instantiate/generate-new-project.ts
+++ b/packages/skaff-lib/src/actions/instantiate/generate-new-project.ts
@@ -3,7 +3,7 @@ import { ProjectCreationOptions, ProjectCreationResult, Result } from "../../lib
 import { resolveProjectCreationManager } from "../../core/projects/ProjectCreationManager";
 
 export async function generateNewProject(
-  projectName: string,
+  projectRepositoryName: string,
   templateName: string,
   newProjectParentDirPath: string,
   userTemplateSettings: UserTemplateSettings,
@@ -13,7 +13,7 @@ export async function generateNewProject(
   return await projectCreationManager.instantiateProject(
     templateName,
     newProjectParentDirPath,
-    projectName,
+    projectRepositoryName,
     userTemplateSettings,
     projectCreationOptions,
   );

--- a/packages/skaff-lib/src/actions/template/load-project-template-revision.ts
+++ b/packages/skaff-lib/src/actions/template/load-project-template-revision.ts
@@ -14,10 +14,10 @@ export async function loadProjectTemplateRevision(
 
   if (!commitHash) {
     logError({
-      shortMessage: `No commit hash found for project ${project.instantiatedProjectSettings.projectName}`,
+      shortMessage: `No commit hash found for project ${project.instantiatedProjectSettings.projectRepositoryName}`,
     });
     return {
-      error: `No commit hash found for project ${project.instantiatedProjectSettings.projectName}`,
+      error: `No commit hash found for project ${project.instantiatedProjectSettings.projectRepositoryName}`,
     };
   }
 

--- a/packages/skaff-lib/src/core/diffing/ProjectDiffPlanner.ts
+++ b/packages/skaff-lib/src/core/diffing/ProjectDiffPlanner.ts
@@ -84,12 +84,12 @@ export class ProjectDiffPlanner {
       };
     }
 
-    const tempOldProjectName = `${oldProjectSettings.projectName}-${crypto.randomUUID()}`;
-    const tempNewProjectName = `${oldProjectSettings.projectName}-${crypto.randomUUID()}`;
+    const tempOldProjectRepositoryName = `${oldProjectSettings.projectRepositoryName}-${crypto.randomUUID()}`;
+    const tempNewProjectRepositoryName = `${oldProjectSettings.projectRepositoryName}-${crypto.randomUUID()}`;
 
     const tempOldResult = await this.tempProjectFactory.createFromSettings(
       oldProjectSettings,
-      tempOldProjectName,
+      tempOldProjectRepositoryName,
     );
 
     if ("error" in tempOldResult) {
@@ -98,7 +98,7 @@ export class ProjectDiffPlanner {
 
     const tempNewResult = await this.tempProjectFactory.createFromSettings(
       newProjectSettings,
-      tempNewProjectName,
+      tempNewProjectRepositoryName,
     );
 
     if ("error" in tempNewResult) {
@@ -559,10 +559,10 @@ export class ProjectDiffPlanner {
       };
     }
 
-    const tempProjectName = `${project.instantiatedProjectSettings.projectName}-${crypto.randomUUID()}`;
+    const tempProjectRepositoryName = `${project.instantiatedProjectSettings.projectRepositoryName}-${crypto.randomUUID()}`;
     const tempProjectResult = await this.tempProjectFactory.createFromExistingProject(
       project,
-      tempProjectName,
+      tempProjectRepositoryName,
     );
 
     if ("error" in tempProjectResult) {

--- a/packages/skaff-lib/src/core/generation/ProjectSettingsSynchronizer.ts
+++ b/packages/skaff-lib/src/core/generation/ProjectSettingsSynchronizer.ts
@@ -91,10 +91,10 @@ export class ProjectSettingsSynchronizer {
   ): Result<string> {
     if (this.destinationProjectSettings.instantiatedTemplates.length > 0) {
       backendLogger.error(
-        `Project ${this.destinationProjectSettings.projectName} already has instantiated templates.`,
+        `Project ${this.destinationProjectSettings.projectRepositoryName} already has instantiated templates.`,
       );
       return {
-        error: `Project ${this.destinationProjectSettings.projectName} already has instantiated templates.`,
+        error: `Project ${this.destinationProjectSettings.projectRepositoryName} already has instantiated templates.`,
       };
     }
 

--- a/packages/skaff-lib/src/core/generation/template-generator-service.ts
+++ b/packages/skaff-lib/src/core/generation/template-generator-service.ts
@@ -506,7 +506,7 @@ export class TemplateGenerationSession {
       if (!this.options.dontDoGit) {
         const commitResult = await this.gitService.commitAll(
           this.options.absoluteDestinationPath,
-          `Initial commit for ${projectSettings.projectName}`,
+          `Initial commit for ${projectSettings.projectRepositoryName}`,
         );
         if ("error" in commitResult) {
           return fail(commitResult);

--- a/packages/skaff-lib/src/core/projects/ProjectCreationManager.ts
+++ b/packages/skaff-lib/src/core/projects/ProjectCreationManager.ts
@@ -44,12 +44,12 @@ export class ProjectCreationManager {
     options?: ProjectCreationOptions,
   ): Promise<Result<ProjectCreationResult>> {
     const projectRepository = this.projectRepository;
-    const newProjectName = path.basename(projectPath);
+    const newProjectRepositoryName = path.basename(projectPath);
     const newProjectParentDir = path.dirname(projectPath);
 
-    const project = await projectRepository.findProjectByName(
+    const project = await projectRepository.findProjectByRepositoryName(
       newProjectParentDir,
-      newProjectName,
+      newProjectRepositoryName,
     );
 
     if ("error" in project) {
@@ -57,7 +57,7 @@ export class ProjectCreationManager {
     }
 
     if (!project.data) {
-      backendLogger.error(`Project ${newProjectName} not found after creation`);
+      backendLogger.error(`Project ${newProjectRepositoryName} not found after creation`);
       return {
         error: "Failed to create project, project not found after creation",
       };
@@ -95,7 +95,7 @@ export class ProjectCreationManager {
   public async instantiateProject(
     rootTemplateName: string,
     parentDirPath: string,
-    newProjectName: string,
+    newProjectRepositoryName: string,
     userTemplateSettings: UserTemplateSettings,
     projectCreationOptions?: ProjectCreationOptions,
   ): Promise<Result<ProjectCreationResult>> {
@@ -115,7 +115,7 @@ export class ProjectCreationManager {
     return template.data.instantiateNewProject(
       userTemplateSettings,
       parentDirPath,
-      newProjectName,
+      newProjectRepositoryName,
       projectCreationOptions,
       this.templateGenerator,
     );

--- a/packages/skaff-lib/src/core/templates/Template.ts
+++ b/packages/skaff-lib/src/core/templates/Template.ts
@@ -146,12 +146,12 @@ export class Template {
   public async instantiateNewProject(
     rootTemplateSettings: UserTemplateSettings,
     destinationDir: string,
-    projectName: string,
+    projectRepositoryName: string,
     projectCreationOptions?: ProjectCreationOptions,
     templateGeneratorService?: TemplateGeneratorService,
   ): Promise<Result<ProjectCreationResult>> {
     const newProjectSettings: ProjectSettings = {
-      projectName,
+      projectRepositoryName,
       projectAuthor: "abc",
       rootTemplateName: this.config.templateConfig.name,
       instantiatedTemplates: [],
@@ -161,7 +161,7 @@ export class Template {
       templateGeneratorService ?? resolveTemplateGeneratorService();
     const generatorSession = generatorService.createSession(
       {
-        absoluteDestinationPath: path.join(destinationDir, projectName),
+        absoluteDestinationPath: path.join(destinationDir, projectRepositoryName),
         dontDoGit: !projectCreationOptions?.git,
       },
       this,

--- a/packages/skaff-lib/src/models/project.ts
+++ b/packages/skaff-lib/src/models/project.ts
@@ -12,8 +12,8 @@ import { resolveShellService } from "../core/infra/shell-service";
 import { Template } from "./template";
 import { backendLogger } from "../lib";
 
-// every project name inside a root project should be unique.
-// The root project can be uniquely identified by its name and author.(and version)
+// Every project repository name inside a root project should be unique.
+// The root project can be uniquely identified by its repository name and author (and version).
 
 function isCrossRepoChild(template: Template): boolean {
   if (!template.parentTemplate) {
@@ -412,7 +412,7 @@ export class Project {
   public mapToDTO(): Result<ProjectDTO> {
     return {
       data: {
-        name: this.instantiatedProjectSettings.projectName,
+        name: this.instantiatedProjectSettings.projectRepositoryName,
         absPath: this.absoluteRootDir,
         rootTemplateName: this.instantiatedProjectSettings.rootTemplateName,
         settings: this.instantiatedProjectSettings,

--- a/packages/skaff-lib/src/repositories/project-repository.ts
+++ b/packages/skaff-lib/src/repositories/project-repository.ts
@@ -52,12 +52,12 @@ export class ProjectRepository {
     return result;
   }
 
-  async findProjectByName(
+  async findProjectByRepositoryName(
     searchPath: string,
-    projectName: string,
+    projectRepositoryName: string,
     cached: boolean = false,
   ): Promise<Result<Project | null>> {
-    const projectPath = path.join(searchPath, projectName);
+    const projectPath = path.join(searchPath, projectRepositoryName);
 
     try {
       const stat = await fs.stat(projectPath);

--- a/packages/skaff-lib/tests/helpers/template-fixtures.ts
+++ b/packages/skaff-lib/tests/helpers/template-fixtures.ts
@@ -24,7 +24,7 @@ import { getSkaffContainer } from "../../src/di/container";
  *   it("works", async () => {
  *     const { template } = await createTestTemplate({
  *       name: "root-template",
- *       files: { "README.hbs": "Hello {{projectName}}" },
+ *       files: { "README.hbs": "Hello {{projectRepositoryName}}" },
  *       subTemplates: [{ name: "child-template" }],
  *     });
  *
@@ -273,7 +273,7 @@ export async function createTestTemplate(
 
 export interface CreateTestProjectOptions {
   template: Template;
-  projectName?: string;
+  projectRepositoryName?: string;
   projectAuthor?: string;
   instantiatedTemplates?: ProjectSettings["instantiatedTemplates"];
   settingsOverrides?: Partial<ProjectSettings>;
@@ -294,11 +294,14 @@ export async function createTestProject(
   options: CreateTestProjectOptions,
 ): Promise<CreateTestProjectResult> {
   const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skaff-project-"));
-  const projectDir = path.join(tempRoot, options.projectName ?? "test-project");
+  const projectDir = path.join(
+    tempRoot,
+    options.projectRepositoryName ?? "test-project",
+  );
   await fs.mkdir(projectDir, { recursive: true });
 
   const baseSettings: ProjectSettings = {
-    projectName: options.projectName ?? "test-project",
+    projectRepositoryName: options.projectRepositoryName ?? "test-project",
     projectAuthor: options.projectAuthor ?? "Test Author",
     rootTemplateName: options.template.config.templateConfig.name,
     instantiatedTemplates: options.instantiatedTemplates ?? [],

--- a/packages/skaff-lib/tests/instantiate-actions.test.ts
+++ b/packages/skaff-lib/tests/instantiate-actions.test.ts
@@ -264,10 +264,10 @@ describe("instantiate actions", () => {
         "../src/actions/instantiate/generate-new-project-from-existing"
       );
 
-      const originalProjectName = "old-project";
+      const originalProjectRepositoryName = "old-project";
       const project = {
         instantiatedProjectSettings: {
-          projectName: originalProjectName,
+          projectRepositoryName: originalProjectRepositoryName,
           rootTemplateName: "root",
           instantiatedTemplates: [],
         },
@@ -286,14 +286,14 @@ describe("instantiate actions", () => {
         mockGenerateProjectFromTemplateSettings.mock.calls[0];
 
       expect(newSettings).toEqual({
-        projectName: "new-project",
+        projectRepositoryName: "new-project",
         rootTemplateName: "root",
         instantiatedTemplates: [],
       });
       expect(destinationPath).toContain("/dest");
       expect(options).toEqual({ dryRun: true });
-      expect(project.instantiatedProjectSettings.projectName).toBe(
-        originalProjectName,
+      expect(project.instantiatedProjectSettings.projectRepositoryName).toBe(
+        originalProjectRepositoryName,
       );
       expect(result).toEqual({ data: creationResult });
     });
@@ -308,7 +308,7 @@ describe("instantiate actions", () => {
 
       const project = {
         instantiatedProjectSettings: {
-          projectName: "old",
+          projectRepositoryName: "old",
           rootTemplateName: "root",
           instantiatedTemplates: [],
         },
@@ -326,7 +326,7 @@ describe("instantiate actions", () => {
     it("parses settings and delegates to facade", async () => {
       const creationResult = { projectPath: "generated" };
       mockProjectSettingsSchemaParse.mockReturnValue({
-        projectName: "old",
+        projectRepositoryName: "old",
         rootTemplateName: "root",
         instantiatedTemplates: [],
       });
@@ -349,7 +349,7 @@ describe("instantiate actions", () => {
 
       expect(mockProjectSettingsSchemaParse).toHaveBeenCalled();
       expect(mockGenerateProjectFromTemplateSettings).toHaveBeenCalledWith({
-        projectName: "project",
+        projectRepositoryName: "project",
         rootTemplateName: "root",
         instantiatedTemplates: [],
       }, expect.any(String), { verbose: true });

--- a/packages/skaff-lib/tests/project-parent-schema.test.ts
+++ b/packages/skaff-lib/tests/project-parent-schema.test.ts
@@ -103,7 +103,7 @@ async function createTemplate({
 describe("Project parent final settings validation", () => {
   function buildProjectSettings(parentName: string, parentValue: string): ProjectSettings {
     return {
-      projectName: "test-project",
+      projectRepositoryName: "test-project",
       projectAuthor: "tester",
       rootTemplateName: parentName,
       instantiatedTemplates: [

--- a/packages/skaff-lib/tests/project-settings-manager.test.ts
+++ b/packages/skaff-lib/tests/project-settings-manager.test.ts
@@ -127,7 +127,7 @@ describe("ProjectSettingsManager.load", () => {
     });
 
     const templateSettings = {
-      projectName: "demo",
+      projectRepositoryName: "demo",
       projectAuthor: "me",
       rootTemplateName: "root",
       instantiatedTemplates: [

--- a/packages/template-types-lib/src/types/index.ts
+++ b/packages/template-types-lib/src/types/index.ts
@@ -30,5 +30,9 @@ export type {
   ProjectSettings,
 } from "./project-settings-types";
 
-export { instantiatedTemplateSchema, projectSettingsSchema, projectNameRegex } from "./project-settings-types";
+export {
+  instantiatedTemplateSchema,
+  projectSettingsSchema,
+  projectRepositoryNameRegex,
+} from "./project-settings-types";
 export { templateConfigSchema } from "./template-config-types";

--- a/packages/template-types-lib/src/types/project-settings-types.ts
+++ b/packages/template-types-lib/src/types/project-settings-types.ts
@@ -17,15 +17,15 @@ export const instantiatedTemplateSchema = z.object({
 
 export type InstantiatedTemplate = z.infer<typeof instantiatedTemplateSchema>;
 
-export const projectNameRegex = /^[a-zA-Z0-9-_]+$/;
+export const projectRepositoryNameRegex = /^[a-zA-Z0-9-_]+$/;
 
 export const projectSettingsSchema = z.object({
-  projectName: z
+  projectRepositoryName: z
     .string()
     .min(1)
     .regex(
-      projectNameRegex,
-      "Project name can only contain letters, numbers, dashes and underscores.",
+      projectRepositoryNameRegex,
+      "Project repository name can only contain letters, numbers, dashes and underscores.",
     ),
   projectAuthor: z.string().min(1),
 


### PR DESCRIPTION
## Summary
- rename the shared project settings schema to use `projectRepositoryName` and export the new regex helper
- update Skaff library workflows, CLI commands, and automated tests to use project repository terminology
- refresh web UI routes, parameters, and messaging so every user touchpoint refers to the project repository name

## Testing
- not run (per instruction)


------
https://chatgpt.com/codex/tasks/task_e_690a9b4d65d483289156411e99e8a574