### PR TITLE
fix: read version without nix develop

### DIFF
--- a/.github/workflows/manualLibRelease.yml
+++ b/.github/workflows/manualLibRelease.yml
@@ -48,7 +48,7 @@ jobs:
       - id: current_version
         name: Read current library version
         run: |
-          version=$(nix develop --impure . --command bash -lc 'jq -r ".version" packages/skaff-lib/package.json')
+          version=$(jq -r '.version' packages/skaff-lib/package.json)
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - id: bump_version


### PR DESCRIPTION
## Summary
- read the library version directly with jq instead of nix develop to avoid extra output

## Testing
- bun run test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691110b24d3083258b22559bd19b2b68)