### PR TITLE
Avoid double auto-instantiation for child templates

### DIFF
--- a/packages/skaff-lib/src/core/generation/AutoInstantiationPlanner.ts
+++ b/packages/skaff-lib/src/core/generation/AutoInstantiationPlanner.ts
@@ -166,33 +166,8 @@ export class AutoInstantiationPlanner {
         }
       }
 
-      this.context.setCurrentState({
-        template: templateToInstantiate,
-        finalSettings: childFinalTemplateSettings,
-        parentInstanceId: instantiatedTemplateId,
-      });
-
-      const templatesToAutoInstantiateResult =
-        this.getTemplatesToAutoInstantiateForCurrentTemplate();
-
-      if ("error" in templatesToAutoInstantiateResult) {
-        this.context.setCurrentState(parentState);
-        return templatesToAutoInstantiateResult;
-      }
-
-      if (templatesToAutoInstantiateResult.data.length) {
-        const autoInstantiationResult = await this.autoInstantiateSubTemplates(
-          cloneValue(childFinalTemplateSettings),
-          instantiatedTemplateId,
-          templatesToAutoInstantiateResult.data,
-        );
-
-        if ("error" in autoInstantiationResult) {
-          this.context.setCurrentState(parentState);
-          return autoInstantiationResult;
-        }
-      }
-
+      // The child template's own auto-instantiation routine runs inside
+      // instantiateTemplate, so we only need to restore the parent state here.
       this.context.setCurrentState(parentState);
     }
 


### PR DESCRIPTION
## Summary
- stop AutoInstantiationPlanner from re-running a child's auto-instantiation list after the child instance has already handled it
- add a regression test proving that only the child's own instantiation triggers its auto-instantiated descendants once

## Testing
- bun run test (from packages/skaff-lib)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918b0b5919883289288893c5c7c13b2)