### PR TITLE
Fix union schema building for Zod 4

### DIFF
--- a/apps/web/src/components/general/template-settings/schema-utils.ts
+++ b/apps/web/src/components/general/template-settings/schema-utils.ts
@@ -406,10 +406,11 @@ function buildUnionSchema(jsonSchema: any, path = ""): SchemaResult {
     };
   }
 
-  let unionSchema = variantSchemas[0];
-  for (let i = 1; i < variantSchemas.length; i++) {
-    unionSchema = z.union([unionSchema, variantSchemas[i]]);
-  }
+  const [firstSchema, ...remainingSchemas] = variantSchemas;
+  let unionSchema: z.ZodTypeAny = firstSchema!;
+  remainingSchemas.forEach((schema) => {
+    unionSchema = z.union([unionSchema, schema]);
+  });
 
   if (normalizedSchema.default !== undefined) {
     unionSchema = unionSchema.default(normalizedSchema.default);


### PR DESCRIPTION
## Summary
- ensure union schema construction always starts from a defined base before chaining unions

## Testing
- bun run test *(fails: jest: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a3f10c2e88325b94d0913e3a24a27)