### PR TITLE
Refactor generation pipeline naming and docs

### DIFF
--- a/packages/skaff-lib/src/core/generation/pipeline/AutoInstantiationCoordinator.ts
+++ b/packages/skaff-lib/src/core/generation/pipeline/AutoInstantiationCoordinator.ts
@@ -3,17 +3,25 @@ import {
   FinalTemplateSettings,
   UserTemplateSettings,
 } from "@timonteutelink/template-types-lib";
-import { backendLogger } from "../../lib/logger";
-import { Result } from "../../lib/types";
-import { anyOrCallbackToAny, cloneValue } from "../../lib/utils";
-import { GeneratorOptions } from "./template-generator-service";
-import { GenerationContext } from "./GenerationContext";
-import { ProjectSettingsSynchronizer } from "./ProjectSettingsSynchronizer";
+import { backendLogger } from "../../../lib/logger";
+import { Result } from "../../../lib/types";
+import { anyOrCallbackToAny, cloneValue } from "../../../lib/utils";
+import { GeneratorOptions } from "../template-generator-service";
+import { ProjectSettingsSynchronizer } from "../ProjectSettingsSynchronizer";
+import { TemplatePipelineContext } from "./TemplatePipelineContext";
 
-export class AutoInstantiationPlanner {
+/**
+ * Plans and executes automatic subtemplate instantiation during pipeline runs.
+ *
+ * Templates can declare child templates that should be instantiated whenever a
+ * parent is rendered. This coordinator resolves those declarations, registers
+ * new template instances in project settings, and invokes the template
+ * instantiation pipeline recursively while keeping the parent context intact.
+ */
+export class AutoInstantiationCoordinator {
   constructor(
     private readonly options: GeneratorOptions,
-    private readonly context: GenerationContext,
+    private readonly context: TemplatePipelineContext,
     private readonly projectSettingsSynchronizer: ProjectSettingsSynchronizer,
     private readonly instantiateTemplate: (
       templateInstanceId: string,

--- a/packages/skaff-lib/src/core/generation/pipeline/SideEffectCoordinator.ts
+++ b/packages/skaff-lib/src/core/generation/pipeline/SideEffectCoordinator.ts
@@ -1,17 +1,24 @@
 import { SideEffectFunction } from "@timonteutelink/template-types-lib";
 import fs from "fs-extra";
 import { readFile } from "node:fs/promises";
-import { backendLogger } from "../../lib/logger";
-import { Result } from "../../lib/types";
-import { anyOrCallbackToAny, logError } from "../../lib/utils";
-import { GenerationContext } from "./GenerationContext";
-import { PathResolver } from "./PathResolver";
-import { RollbackFileSystem } from "./RollbackFileSystem";
+import { backendLogger } from "../../../lib/logger";
+import { Result } from "../../../lib/types";
+import { anyOrCallbackToAny, logError } from "../../../lib/utils";
+import { RollbackFileSystem } from "../RollbackFileSystem";
+import { TargetPathResolver } from "./TargetPathResolver";
+import { TemplatePipelineContext } from "./TemplatePipelineContext";
 
-export class SideEffectExecutor {
+/**
+ * Applies side-effect functions after template files are rendered.
+ *
+ * The coordinator resolves the target paths using the current pipeline context
+ * and ensures files are prepared for rollback. It is used as a pipeline stage
+ * to mutate generated files according to template-provided callbacks.
+ */
+export class SideEffectCoordinator {
   constructor(
-    private readonly context: GenerationContext,
-    private readonly pathResolver: PathResolver,
+    private readonly context: TemplatePipelineContext,
+    private readonly pathResolver: TargetPathResolver,
     private readonly fileSystem: RollbackFileSystem,
   ) {}
 

--- a/packages/skaff-lib/src/core/generation/pipeline/TargetPathResolver.ts
+++ b/packages/skaff-lib/src/core/generation/pipeline/TargetPathResolver.ts
@@ -1,12 +1,19 @@
 import path from "node:path";
-import { Result } from "../../lib/types";
-import { stringOrCallbackToString } from "../../lib/utils";
-import { GenerationContext } from "./GenerationContext";
+import { Result } from "../../../lib/types";
+import { stringOrCallbackToString } from "../../../lib/utils";
+import { TemplatePipelineContext } from "./TemplatePipelineContext";
 
-export class PathResolver {
+/**
+ * Resolves template-defined paths relative to the pipeline destination root.
+ *
+ * This resolver prevents templates from escaping the project directory and
+ * centralizes the logic for translating relative target paths into absolute
+ * filesystem locations consumed by later pipeline stages.
+ */
+export class TargetPathResolver {
   constructor(
     private readonly absoluteDestinationPath: string,
-    private readonly context: GenerationContext,
+    private readonly context: TemplatePipelineContext,
   ) {}
 
   public getProjectRoot(): string {

--- a/packages/skaff-lib/src/core/generation/pipeline/TemplateFileMaterializer.ts
+++ b/packages/skaff-lib/src/core/generation/pipeline/TemplateFileMaterializer.ts
@@ -7,13 +7,13 @@ import { glob } from "glob";
 import { HelperDelegate } from "handlebars";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { backendLogger } from "../../lib/logger";
-import { Result } from "../../lib/types";
-import { anyOrCallbackToAny, logError } from "../../lib/utils";
-import { HandlebarsEnvironment } from "../shared/HandlebarsEnvironment";
-import { GenerationContext } from "./GenerationContext";
-import { PathResolver } from "./PathResolver";
-import { RollbackFileSystem } from "./RollbackFileSystem";
+import { backendLogger } from "../../../lib/logger";
+import { Result } from "../../../lib/types";
+import { anyOrCallbackToAny, logError } from "../../../lib/utils";
+import { HandlebarsEnvironment } from "../../shared/HandlebarsEnvironment";
+import { RollbackFileSystem } from "../RollbackFileSystem";
+import { TargetPathResolver } from "./TargetPathResolver";
+import { TemplatePipelineContext } from "./TemplatePipelineContext";
 
 function isBinaryContent(buffer: Buffer): boolean {
   const length = Math.min(buffer.length, 512);
@@ -36,10 +36,19 @@ function isBinaryContent(buffer: Buffer): boolean {
   return false;
 }
 
-export class FileMaterializer {
+/**
+ * Renders template files into the target path for the current pipeline state.
+ *
+ * The materializer prepares Handlebars helpers/partials, resolves redirects and
+ * overwrite rules, and copies assets to the destination directory tracked by
+ * the {@link TemplatePipelineContext}. It is used by both project creation and
+ * template instantiation stages to ensure file output stays consistent across
+ * pipeline runs.
+ */
+export class TemplateFileMaterializer {
   constructor(
-    private readonly context: GenerationContext,
-    private readonly pathResolver: PathResolver,
+    private readonly context: TemplatePipelineContext,
+    private readonly pathResolver: TargetPathResolver,
     private readonly fileSystem: RollbackFileSystem,
     private readonly handlebars: HandlebarsEnvironment,
   ) {}

--- a/packages/skaff-lib/src/core/generation/pipeline/index.ts
+++ b/packages/skaff-lib/src/core/generation/pipeline/index.ts
@@ -1,0 +1,7 @@
+export * from "./TemplatePipelineContext";
+export * from "./TargetPathResolver";
+export * from "./TemplateFileMaterializer";
+export * from "./SideEffectCoordinator";
+export * from "./AutoInstantiationCoordinator";
+export * from "./pipeline-runner";
+export * from "./pipeline-stages";

--- a/packages/skaff-lib/src/core/generation/pipeline/pipeline-runner.ts
+++ b/packages/skaff-lib/src/core/generation/pipeline/pipeline-runner.ts
@@ -1,12 +1,19 @@
 import type { Result } from "../../../lib/types";
 
-export interface TemplateGenerationStage<TContext> {
+export interface PipelineStage<TContext> {
   readonly name: string;
   run(context: TContext): Promise<Result<TContext>>;
 }
 
-export class TemplateGenerationPipeline<TContext> {
-  constructor(private readonly stages: TemplateGenerationStage<TContext>[]) { }
+/**
+ * Executes a sequence of pipeline stages while threading context between them.
+ *
+ * The runner enforces stage ordering and short-circuits on the first failure
+ * so callers can rely on a single, linear control flow for template
+ * generation.
+ */
+export class PipelineRunner<TContext> {
+  constructor(private readonly stages: PipelineStage<TContext>[]) { }
 
   public async run(context: TContext): Promise<Result<TContext>> {
     let currentContext = context;

--- a/packages/skaff-lib/src/core/generation/pipeline/pipeline-stages.ts
+++ b/packages/skaff-lib/src/core/generation/pipeline/pipeline-stages.ts
@@ -8,18 +8,18 @@ import fs from "fs-extra";
 import { backendLogger } from "../../../lib/logger";
 import { anyOrCallbackToAny } from "../../../lib/utils";
 import { isSubset } from "../../../utils/shared-utils";
-import type { Template } from "../../models/template";
-import { TemplateGenerationPipeline } from "./generation-pipeline";
-import type { FileMaterializer } from "./../FileMaterializer";
-import type { GenerationContext } from "./../GenerationContext";
-import type { PathResolver } from "./../PathResolver";
-import type { ProjectSettingsSynchronizer } from "./../ProjectSettingsSynchronizer";
-import type { SideEffectExecutor } from "./../SideEffectExecutor";
-import type { AutoInstantiationPlanner } from "./../AutoInstantiationPlanner";
-import type { GitService } from "../../infra/git-service";
+import type { Template } from "../../../models/template";
 import { makeDir } from "../../infra/file-service";
+import type { GitService } from "../../infra/git-service";
 import type { GeneratorOptions } from "../template-generator-service";
-import type { TemplateGenerationStage } from "./generation-pipeline";
+import type { ProjectSettingsSynchronizer } from "../ProjectSettingsSynchronizer";
+import type { AutoInstantiationCoordinator } from "./AutoInstantiationCoordinator";
+import type { PipelineStage } from "./pipeline-runner";
+import { PipelineRunner } from "./pipeline-runner";
+import type { SideEffectCoordinator } from "./SideEffectCoordinator";
+import type { TargetPathResolver } from "./TargetPathResolver";
+import type { TemplateFileMaterializer } from "./TemplateFileMaterializer";
+import type { TemplatePipelineContext } from "./TemplatePipelineContext";
 
 export interface TemplateInstantiationPipelineContext {
   template: Template;
@@ -42,22 +42,29 @@ export interface ProjectCreationPipelineContext {
 }
 
 export const createTemplateInstantiationPipeline = (
-  stages: TemplateGenerationStage<TemplateInstantiationPipelineContext>[],
-): TemplateGenerationPipeline<TemplateInstantiationPipelineContext> =>
-  new TemplateGenerationPipeline<TemplateInstantiationPipelineContext>(stages);
+  stages: PipelineStage<TemplateInstantiationPipelineContext>[],
+): PipelineRunner<TemplateInstantiationPipelineContext> =>
+  new PipelineRunner<TemplateInstantiationPipelineContext>(stages);
 
 export const createProjectCreationPipeline = (
-  stages: TemplateGenerationStage<ProjectCreationPipelineContext>[],
-): TemplateGenerationPipeline<ProjectCreationPipelineContext> =>
-  new TemplateGenerationPipeline<ProjectCreationPipelineContext>(stages);
+  stages: PipelineStage<ProjectCreationPipelineContext>[],
+): PipelineRunner<ProjectCreationPipelineContext> =>
+  new PipelineRunner<ProjectCreationPipelineContext>(stages);
 
+/**
+ * Initializes pipeline context with resolved template settings.
+ *
+ * This stage validates the template repository, resolves user settings into
+ * final template settings, and stores them on the shared pipeline context so
+ * downstream stages can render files and apply side effects with confidence.
+ */
 export class ContextSetupStage
-  implements TemplateGenerationStage<TemplateInstantiationPipelineContext>
+  implements PipelineStage<TemplateInstantiationPipelineContext>
 {
   public readonly name = "context-setup";
 
   constructor(
-    private readonly generationContext: GenerationContext,
+    private readonly pipelineContext: TemplatePipelineContext,
     private readonly projectSettingsSynchronizer: ProjectSettingsSynchronizer,
   ) { }
 
@@ -84,7 +91,7 @@ export class ContextSetupStage
       return result;
     }
 
-    this.generationContext.setCurrentState({
+    this.pipelineContext.setCurrentState({
       template: context.template,
       finalSettings: result.data,
       parentInstanceId: context.parentInstanceId,
@@ -96,8 +103,15 @@ export class ContextSetupStage
   }
 }
 
+/**
+ * Guards against incompatible template combinations and failing assertions.
+ *
+ * By stopping the pipeline early when a template conflicts with an already
+ * instantiated one or fails custom assertions, the stage prevents wasted work
+ * later in the pipeline.
+ */
 export class TemplateValidationStage
-  implements TemplateGenerationStage<TemplateInstantiationPipelineContext>
+  implements PipelineStage<TemplateInstantiationPipelineContext>
 {
   public readonly name = "template-validation";
 
@@ -170,12 +184,18 @@ export class TemplateValidationStage
   }
 }
 
+/**
+ * Copies and renders template files into the destination directory.
+ *
+ * Relies on the {@link TemplateFileMaterializer} to honor redirects,
+ * overwrites, and Handlebars helpers/partials for the active template.
+ */
 export class RenderStage
-  implements TemplateGenerationStage<TemplateInstantiationPipelineContext>
+  implements PipelineStage<TemplateInstantiationPipelineContext>
 {
   public readonly name = "render";
 
-  constructor(private readonly fileMaterializer: FileMaterializer) { }
+  constructor(private readonly fileMaterializer: TemplateFileMaterializer) { }
 
   public async run(
     context: TemplateInstantiationPipelineContext,
@@ -190,18 +210,24 @@ export class RenderStage
   }
 }
 
+/**
+ * Executes template-defined side-effect functions after rendering.
+ *
+ * This stage allows templates to mutate generated files (for example updating
+ * manifests) while still participating in rollback management.
+ */
 export class SideEffectsStage
-  implements TemplateGenerationStage<TemplateInstantiationPipelineContext>
+  implements PipelineStage<TemplateInstantiationPipelineContext>
 {
   public readonly name = "side-effects";
 
-  constructor(private readonly sideEffectExecutor: SideEffectExecutor) { }
+  constructor(private readonly sideEffectCoordinator: SideEffectCoordinator) { }
 
   public async run(
     context: TemplateInstantiationPipelineContext,
   ): Promise<{ data: TemplateInstantiationPipelineContext } | { error: string }>
   {
-    const sideEffectResult = await this.sideEffectExecutor.applySideEffects();
+    const sideEffectResult = await this.sideEffectCoordinator.applySideEffects();
     if ("error" in sideEffectResult) {
       return sideEffectResult;
     }
@@ -210,8 +236,14 @@ export class SideEffectsStage
   }
 }
 
+/**
+ * Persists the template's resolved settings back to the project configuration.
+ *
+ * Running after rendering ensures the project settings reflect what was
+ * actually generated, enabling reproducible updates and diffs.
+ */
 export class PersistTemplateSettingsStage
-  implements TemplateGenerationStage<TemplateInstantiationPipelineContext>
+  implements PipelineStage<TemplateInstantiationPipelineContext>
 {
   public readonly name = "persist-template-settings";
 
@@ -243,12 +275,19 @@ export class PersistTemplateSettingsStage
   }
 }
 
+/**
+ * Triggers automatic instantiation of child templates declared by the current
+ * template.
+ *
+ * Delegates to the {@link AutoInstantiationCoordinator} to hydrate project
+ * settings and invoke nested pipeline runs when required.
+ */
 export class AutoInstantiationStage
-  implements TemplateGenerationStage<TemplateInstantiationPipelineContext>
+  implements PipelineStage<TemplateInstantiationPipelineContext>
 {
   public readonly name = "auto-instantiation";
 
-  constructor(private readonly autoInstantiationPlanner: AutoInstantiationPlanner) { }
+  constructor(private readonly autoInstantiationCoordinator: AutoInstantiationCoordinator) { }
 
   public async run(
     context: TemplateInstantiationPipelineContext,
@@ -259,7 +298,7 @@ export class AutoInstantiationStage
     }
 
     const templatesToAutoInstantiateResult =
-      this.autoInstantiationPlanner.getTemplatesToAutoInstantiateForCurrentTemplate();
+      this.autoInstantiationCoordinator.getTemplatesToAutoInstantiateForCurrentTemplate();
 
     if ("error" in templatesToAutoInstantiateResult) {
       return templatesToAutoInstantiateResult;
@@ -267,7 +306,7 @@ export class AutoInstantiationStage
 
     if (templatesToAutoInstantiateResult.data.length) {
       const autoInstantiationResult =
-        await this.autoInstantiationPlanner.autoInstantiateSubTemplates(
+        await this.autoInstantiationCoordinator.autoInstantiateSubTemplates(
           context.finalSettings,
           context.instantiatedTemplate.id,
           templatesToAutoInstantiateResult.data,
@@ -282,27 +321,33 @@ export class AutoInstantiationStage
   }
 }
 
+/**
+ * Resolves and stores the final target path for the rendered template.
+ *
+ * This stage must run after settings are finalized so that subsequent steps
+ * (like git commits) know exactly where artifacts landed.
+ */
 export class TargetPathStage
-  implements TemplateGenerationStage<TemplateInstantiationPipelineContext>
+  implements PipelineStage<TemplateInstantiationPipelineContext>
 {
   public readonly name = "target-path";
 
   constructor(
-    private readonly pathResolver: PathResolver,
-    private readonly generationContext: GenerationContext,
+    private readonly targetPathResolver: TargetPathResolver,
+    private readonly pipelineContext: TemplatePipelineContext,
   ) { }
 
   public async run(
     context: TemplateInstantiationPipelineContext,
   ): Promise<{ data: TemplateInstantiationPipelineContext } | { error: string }>
   {
-    const targetPathResult = this.pathResolver.getAbsoluteTargetPath();
+    const targetPathResult = this.targetPathResolver.getAbsoluteTargetPath();
 
     if ("error" in targetPathResult) {
       return targetPathResult;
     }
 
-    const finalSettingsResult = this.generationContext.getFinalSettings();
+    const finalSettingsResult = this.pipelineContext.getFinalSettings();
 
     if ("error" in finalSettingsResult) {
       return finalSettingsResult;
@@ -315,8 +360,14 @@ export class TargetPathStage
   }
 }
 
+/**
+ * Prepares the destination directory and initializes repository state.
+ *
+ * Ensures the project folder exists, initializes git (when enabled), and
+ * persists a fresh project settings file before any rendering occurs.
+ */
 export class ProjectSetupStage
-  implements TemplateGenerationStage<ProjectCreationPipelineContext>
+  implements PipelineStage<ProjectCreationPipelineContext>
 {
   public readonly name = "project-setup";
 
@@ -388,12 +439,18 @@ export class ProjectSetupStage
   }
 }
 
+/**
+ * Renders the root project template into the prepared directory.
+ *
+ * Uses the {@link TemplateFileMaterializer} so project creation follows the
+ * same rendering rules as individual template instantiation.
+ */
 export class ProjectRenderingStage
-  implements TemplateGenerationStage<ProjectCreationPipelineContext>
+  implements PipelineStage<ProjectCreationPipelineContext>
 {
   public readonly name = "project-render";
 
-  constructor(private readonly fileMaterializer: FileMaterializer) { }
+  constructor(private readonly fileMaterializer: TemplateFileMaterializer) { }
 
   public async run(
     context: ProjectCreationPipelineContext,
@@ -408,18 +465,24 @@ export class ProjectRenderingStage
   }
 }
 
+/**
+ * Runs project-level side effects after the main render.
+ *
+ * Allows templates to adjust files (e.g. installing dependencies) while
+ * respecting rollback behaviour shared across the pipeline.
+ */
 export class ProjectSideEffectsStage
-  implements TemplateGenerationStage<ProjectCreationPipelineContext>
+  implements PipelineStage<ProjectCreationPipelineContext>
 {
   public readonly name = "project-side-effects";
 
-  constructor(private readonly sideEffectExecutor: SideEffectExecutor) { }
+  constructor(private readonly sideEffectCoordinator: SideEffectCoordinator) { }
 
   public async run(
     context: ProjectCreationPipelineContext,
   ): Promise<{ data: ProjectCreationPipelineContext } | { error: string }>
   {
-    const sideEffectResult = await this.sideEffectExecutor.applySideEffects();
+    const sideEffectResult = await this.sideEffectCoordinator.applySideEffects();
     if ("error" in sideEffectResult) {
       return sideEffectResult;
     }
@@ -428,12 +491,18 @@ export class ProjectSideEffectsStage
   }
 }
 
+/**
+ * Autoinstantiates subtemplates immediately after the root project is created.
+ *
+ * This stage ensures nested templates are rendered with the same parent
+ * context and settings that were produced during project creation.
+ */
 export class ProjectAutoInstantiationStage
-  implements TemplateGenerationStage<ProjectCreationPipelineContext>
+  implements PipelineStage<ProjectCreationPipelineContext>
 {
   public readonly name = "project-auto-instantiation";
 
-  constructor(private readonly autoInstantiationPlanner: AutoInstantiationPlanner) { }
+  constructor(private readonly autoInstantiationCoordinator: AutoInstantiationCoordinator) { }
 
   public async run(
     context: ProjectCreationPipelineContext,
@@ -444,7 +513,7 @@ export class ProjectAutoInstantiationStage
     }
 
     const templatesToAutoInstantiateResult =
-      this.autoInstantiationPlanner.getTemplatesToAutoInstantiateForCurrentTemplate();
+      this.autoInstantiationCoordinator.getTemplatesToAutoInstantiateForCurrentTemplate();
 
     if ("error" in templatesToAutoInstantiateResult) {
       return templatesToAutoInstantiateResult;
@@ -452,7 +521,7 @@ export class ProjectAutoInstantiationStage
 
     if (templatesToAutoInstantiateResult.data.length) {
       const autoInstantiationResult =
-        await this.autoInstantiationPlanner.autoInstantiateSubTemplates(
+        await this.autoInstantiationCoordinator.autoInstantiateSubTemplates(
           context.finalSettings,
           context.projectSettings.instantiatedTemplates[0]?.id ?? "",
           templatesToAutoInstantiateResult.data,
@@ -469,43 +538,46 @@ export class ProjectAutoInstantiationStage
 
 export const buildDefaultTemplateInstantiationStages = (
   dependencies: {
-    generationContext: GenerationContext;
+    pipelineContext: TemplatePipelineContext;
     projectSettingsSynchronizer: ProjectSettingsSynchronizer;
-    fileMaterializer: FileMaterializer;
-    sideEffectExecutor: SideEffectExecutor;
-    autoInstantiationPlanner: AutoInstantiationPlanner;
-    pathResolver: PathResolver;
+    fileMaterializer: TemplateFileMaterializer;
+    sideEffectCoordinator: SideEffectCoordinator;
+    autoInstantiationCoordinator: AutoInstantiationCoordinator;
+    targetPathResolver: TargetPathResolver;
   },
   options: GeneratorOptions,
   projectSettings: ProjectSettings,
-): TemplateGenerationStage<TemplateInstantiationPipelineContext>[] => [
+): PipelineStage<TemplateInstantiationPipelineContext>[] => [
   new ContextSetupStage(
-    dependencies.generationContext,
+    dependencies.pipelineContext,
     dependencies.projectSettingsSynchronizer,
   ),
   new TemplateValidationStage(projectSettings),
   new RenderStage(dependencies.fileMaterializer),
-  new SideEffectsStage(dependencies.sideEffectExecutor),
+  new SideEffectsStage(dependencies.sideEffectCoordinator),
   new PersistTemplateSettingsStage(
     dependencies.projectSettingsSynchronizer,
     options,
   ),
-  new AutoInstantiationStage(dependencies.autoInstantiationPlanner),
-  new TargetPathStage(dependencies.pathResolver, dependencies.generationContext),
+  new AutoInstantiationStage(dependencies.autoInstantiationCoordinator),
+  new TargetPathStage(
+    dependencies.targetPathResolver,
+    dependencies.pipelineContext,
+  ),
 ];
 
 export const buildDefaultProjectCreationStages = (
   dependencies: {
     projectSettingsSynchronizer: ProjectSettingsSynchronizer;
-    fileMaterializer: FileMaterializer;
-    sideEffectExecutor: SideEffectExecutor;
-    autoInstantiationPlanner: AutoInstantiationPlanner;
+    fileMaterializer: TemplateFileMaterializer;
+    sideEffectCoordinator: SideEffectCoordinator;
+    autoInstantiationCoordinator: AutoInstantiationCoordinator;
   },
   options: GeneratorOptions,
   gitService: GitService,
-): TemplateGenerationStage<ProjectCreationPipelineContext>[] => [
+): PipelineStage<ProjectCreationPipelineContext>[] => [
   new ProjectSetupStage(options, gitService, dependencies.projectSettingsSynchronizer),
   new ProjectRenderingStage(dependencies.fileMaterializer),
-  new ProjectSideEffectsStage(dependencies.sideEffectExecutor),
-  new ProjectAutoInstantiationStage(dependencies.autoInstantiationPlanner),
+  new ProjectSideEffectsStage(dependencies.sideEffectCoordinator),
+  new ProjectAutoInstantiationStage(dependencies.autoInstantiationCoordinator),
 ];

--- a/packages/skaff-lib/src/index.ts
+++ b/packages/skaff-lib/src/index.ts
@@ -6,6 +6,36 @@ export * from "./repositories";
 export * from "./models";
 export * from "./lib";
 export * from "./actions";
+export * from "./core/generation/template-generator-service";
+export {
+  PipelineBuilder,
+  PipelineRunner,
+  type PipelineStage,
+} from "./core/generation/pipeline/pipeline-runner";
+export {
+  buildDefaultProjectCreationStages,
+  buildDefaultTemplateInstantiationStages,
+  ContextSetupStage,
+  TemplateValidationStage,
+  RenderStage,
+  SideEffectsStage,
+  PersistTemplateSettingsStage,
+  AutoInstantiationStage,
+  TargetPathStage,
+  ProjectSetupStage,
+  ProjectRenderingStage,
+  ProjectSideEffectsStage,
+  ProjectAutoInstantiationStage,
+  type ProjectCreationPipelineContext,
+  type TemplateInstantiationPipelineContext,
+} from "./core/generation/pipeline/pipeline-stages";
+export {
+  TemplatePipelineContext,
+  TargetPathResolver,
+  TemplateFileMaterializer,
+  SideEffectCoordinator,
+  AutoInstantiationCoordinator,
+} from "./core/generation/pipeline";
 
 export { findTemplate, projectSearchPathKey } from "./utils/shared-utils";
 export { CacheService, resolveCacheService } from "./core/infra/cache-service";

--- a/packages/skaff-lib/tests/auto-instantiation-planner.test.ts
+++ b/packages/skaff-lib/tests/auto-instantiation-planner.test.ts
@@ -10,16 +10,16 @@ jest.mock("../src/lib/logger", () => ({
   },
 }));
 
-type GenerationState = {
+type PipelineState = {
   template: any;
   finalSettings: any;
   parentInstanceId?: string;
 };
 
-class StubGenerationContext {
-  private state?: GenerationState;
+class StubPipelineContext {
+  private state?: PipelineState;
 
-  constructor(initialState: GenerationState) {
+  constructor(initialState: PipelineState) {
     this.state = initialState;
   }
 
@@ -27,19 +27,19 @@ class StubGenerationContext {
     return this.state ? { data: this.state } : { error: "no state" };
   }
 
-  public setCurrentState(state: GenerationState) {
+  public setCurrentState(state: PipelineState) {
     this.state = state;
   }
 }
 
-describe("AutoInstantiationPlanner", () => {
+describe("AutoInstantiationCoordinator", () => {
   it("passes instantiated final settings to child mapSettings", async () => {
     jest.resetModules();
     jest.doMock("../src/models/template", () => ({
       Template: class {},
     }));
 
-    const { AutoInstantiationPlanner } = require("../src/core/generation/AutoInstantiationPlanner") as typeof import("../src/core/generation/AutoInstantiationPlanner");
+    const { AutoInstantiationCoordinator } = require("../src/core/generation/pipeline/AutoInstantiationCoordinator") as typeof import("../src/core/generation/pipeline/AutoInstantiationCoordinator");
 
     const parentTemplate: any = {
       config: { templateConfig: { name: "parent" }, autoInstantiatedSubtemplates: undefined },
@@ -65,7 +65,7 @@ describe("AutoInstantiationPlanner", () => {
       name === "grandchild" ? grandchildTemplate : undefined,
     );
 
-    const context = new StubGenerationContext({
+    const context = new StubPipelineContext({
       template: parentTemplate,
       finalSettings: { parent: true },
       parentInstanceId: "root-id",
@@ -98,7 +98,7 @@ describe("AutoInstantiationPlanner", () => {
       addNewTemplate,
     };
 
-    const planner = new AutoInstantiationPlanner(
+    const planner = new AutoInstantiationCoordinator(
       { dontAutoInstantiate: false } as any,
       context as any,
       projectSettingsSynchronizer as any,
@@ -140,7 +140,7 @@ describe("AutoInstantiationPlanner", () => {
       Template: class {},
     }));
 
-    const { AutoInstantiationPlanner } = require("../src/core/generation/AutoInstantiationPlanner") as typeof import("../src/core/generation/AutoInstantiationPlanner");
+    const { AutoInstantiationCoordinator } = require("../src/core/generation/pipeline/AutoInstantiationCoordinator") as typeof import("../src/core/generation/pipeline/AutoInstantiationCoordinator");
 
     const parentTemplate: any = {
       config: {
@@ -161,7 +161,7 @@ describe("AutoInstantiationPlanner", () => {
 
     parentTemplate.findSubTemplate.mockReturnValue(childTemplate);
 
-    const context = new StubGenerationContext({
+    const context = new StubPipelineContext({
       template: parentTemplate,
       finalSettings: { parent: true },
       parentInstanceId: "root-id",
@@ -187,7 +187,7 @@ describe("AutoInstantiationPlanner", () => {
       addNewTemplate,
     };
 
-    const planner = new AutoInstantiationPlanner(
+    const planner = new AutoInstantiationCoordinator(
       { dontAutoInstantiate: false } as any,
       context as any,
       projectSettingsSynchronizer as any,
@@ -226,7 +226,7 @@ describe("AutoInstantiationPlanner", () => {
       Template: class {},
     }));
 
-    const { AutoInstantiationPlanner } = require("../src/core/generation/AutoInstantiationPlanner") as typeof import("../src/core/generation/AutoInstantiationPlanner");
+    const { AutoInstantiationCoordinator } = require("../src/core/generation/pipeline/AutoInstantiationCoordinator") as typeof import("../src/core/generation/pipeline/AutoInstantiationCoordinator");
 
     const parentTemplate: any = {
       config: { templateConfig: { name: "parent" }, autoInstantiatedSubtemplates: undefined },
@@ -257,7 +257,7 @@ describe("AutoInstantiationPlanner", () => {
 
     const parentFinalSettings = { parent: true };
 
-    const context = new StubGenerationContext({
+    const context = new StubPipelineContext({
       template: parentTemplate,
       finalSettings: parentFinalSettings,
       parentInstanceId: "root-id",
@@ -287,7 +287,7 @@ describe("AutoInstantiationPlanner", () => {
       addNewTemplate,
     };
 
-    const planner = new AutoInstantiationPlanner(
+    const planner = new AutoInstantiationCoordinator(
       { dontAutoInstantiate: false } as any,
       context as any,
       projectSettingsSynchronizer as any,
@@ -332,7 +332,7 @@ describe("AutoInstantiationPlanner", () => {
       Template: class {},
     }));
 
-    const { AutoInstantiationPlanner } = require("../src/core/generation/AutoInstantiationPlanner") as typeof import("../src/core/generation/AutoInstantiationPlanner");
+    const { AutoInstantiationCoordinator } = require("../src/core/generation/pipeline/AutoInstantiationCoordinator") as typeof import("../src/core/generation/pipeline/AutoInstantiationCoordinator");
 
     const parentTemplate: any = {
       config: {
@@ -379,7 +379,7 @@ describe("AutoInstantiationPlanner", () => {
       return undefined;
     });
 
-    const context = new StubGenerationContext({
+    const context = new StubPipelineContext({
       template: parentTemplate,
       finalSettings: { parent: true },
       parentInstanceId: "root-id",
@@ -398,7 +398,7 @@ describe("AutoInstantiationPlanner", () => {
       .mockReturnValueOnce({ data: "child-id" })
       .mockReturnValueOnce({ data: "grandchild-id" });
 
-    let plannerRef: import("../src/core/generation/AutoInstantiationPlanner").AutoInstantiationPlanner;
+    let plannerRef: import("../src/core/generation/pipeline/AutoInstantiationCoordinator").AutoInstantiationCoordinator;
 
     const instantiateTemplate = jest.fn(async (templateInstanceId: string) => {
       const currentStateResult = context.getState();
@@ -470,7 +470,7 @@ describe("AutoInstantiationPlanner", () => {
       addNewTemplate,
     };
 
-    const planner = new AutoInstantiationPlanner(
+    const planner = new AutoInstantiationCoordinator(
       { dontAutoInstantiate: false } as any,
       context as any,
       projectSettingsSynchronizer as any,

--- a/packages/skaff-lib/tests/pipeline-builder.test.ts
+++ b/packages/skaff-lib/tests/pipeline-builder.test.ts
@@ -1,0 +1,50 @@
+import {
+  PipelineBuilder,
+  PipelineRunner,
+  PipelineStage,
+} from "../src/core/generation/pipeline/pipeline-runner";
+
+type TraceContext = string[];
+
+function stage(name: string): PipelineStage<TraceContext> {
+  return {
+    name,
+    async run(context) {
+      return { data: [...context, name] };
+    },
+  };
+}
+
+describe("PipelineBuilder", () => {
+  it("reorders pipelines without mutating the originals", async () => {
+    const builder = new PipelineBuilder<TraceContext>([
+      stage("first"),
+      stage("third"),
+    ]);
+
+    builder.insertBefore("third", stage("second"));
+    builder.insertAfter("third", stage("after-third"));
+    builder.replace("first", stage("start"));
+    builder.remove("after-third");
+
+    const runner = new PipelineRunner(builder.build());
+    const result = await runner.run([]);
+
+    expect(result).toEqual({ data: ["start", "second", "third"] });
+  });
+
+  it("falls back to appending stages when anchors are missing", () => {
+    const builder = new PipelineBuilder<TraceContext>([stage("base")]);
+
+    builder.insertBefore("missing", stage("before"));
+    builder.insertAfter("missing", stage("after"));
+    builder.replace("unknown", stage("replacement"));
+
+    expect(builder.build().map((item) => item.name)).toEqual([
+      "before",
+      "base",
+      "after",
+      "replacement",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- reorganized generation pipeline components under clearer pipeline-centric names and locations
- documented pipeline classes and stages to clarify their roles in the generation workflow
- updated generator wiring and tests to use the new coordinators and pipeline runner

## Testing
- bun run test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939ae9be8788328bbba0b10537b7abc)