### PR TITLE
Add manifest validation and deterministic plugin pipelines

### DIFF
--- a/packages/plugin-greeter-cli/src/index.ts
+++ b/packages/plugin-greeter-cli/src/index.ts
@@ -27,13 +27,15 @@ const greeterCliCommand: PluginCliCommand = {
       (entry) => entry.id === targetInstanceId,
     );
 
-    const state = targetInstance?.plugins?.[GREETER_PLUGIN_NAME];
+    const pluginState = targetInstance?.plugins?.[GREETER_PLUGIN_NAME];
+    const persistedMessage = (pluginState?.settings as { message?: string } | undefined)
+      ?.message;
 
     // eslint-disable-next-line no-console
     console.log(
       `👋 Hello from greeter for instance ${targetInstanceId} at ${
         projectPath ?? ""
-      }.${state?.message ? ` Stored message: ${state.message}` : ""}`,
+      }.${persistedMessage ? ` Stored message: ${persistedMessage}` : ""}`,
     );
   },
 };
@@ -71,7 +73,12 @@ const greeterCliContribution: CliPluginContribution = {
 };
 
 const greeterCliPlugin = {
-  name: GREETER_PLUGIN_NAME,
+  manifest: {
+    name: GREETER_PLUGIN_NAME,
+    version: "0.0.0",
+    capabilities: ["cli"],
+    supportedHooks: { template: [], cli: [], web: [] },
+  },
   cli: greeterCliContribution,
 };
 

--- a/packages/plugin-greeter-web/src/index.tsx
+++ b/packages/plugin-greeter-web/src/index.tsx
@@ -83,7 +83,12 @@ const greeterWebContribution: WebPluginContribution = {
 };
 
 const greeterWebPlugin = {
-  name: GREETER_PLUGIN_NAME,
+  manifest: {
+    name: GREETER_PLUGIN_NAME,
+    version: "0.0.0",
+    capabilities: ["web"],
+    supportedHooks: { template: [], cli: [], web: [] },
+  },
   web: greeterWebContribution,
 };
 

--- a/packages/plugin-greeter/src/index.ts
+++ b/packages/plugin-greeter/src/index.ts
@@ -20,7 +20,9 @@ function createGreetingStage(
     "Hello from the greeter plugin!";
 
   return {
+    key: "greeter-greeting",
     name: "greeter-greeting",
+    source: GREETER_PLUGIN_NAME,
     async run(context) {
       // eslint-disable-next-line no-console
       console.log(`👋 ${message}`);
@@ -47,7 +49,20 @@ function createGreeterTemplatePlugin(
 }
 
 const greeterPlugin = {
-  name: GREETER_PLUGIN_NAME,
+  manifest: {
+    name: GREETER_PLUGIN_NAME,
+    version: "0.0.0",
+    capabilities: ["template"],
+    supportedHooks: {
+      template: ["configureTemplateInstantiationPipeline"],
+      cli: [],
+      web: [],
+    },
+    schemas: {
+      additionalTemplateSettings: true,
+      pluginFinalSettings: true,
+    },
+  },
   additionalTemplateSettingsSchema: pluginAdditionalTemplateSettingsSchema,
   pluginFinalSettingsSchema: pluginFinalSettingsSchema.merge(
     z.object({

--- a/packages/skaff-lib/src/core/generation/ProjectSettingsSynchronizer.ts
+++ b/packages/skaff-lib/src/core/generation/ProjectSettingsSynchronizer.ts
@@ -22,7 +22,7 @@ function allowPluginTemplateSettings(
   templateSettingsSchema: z.ZodObject<any>,
 ): z.ZodObject<any> {
   const pluginShape = z.object({
-    plugins: z.record(z.string(), z.unknown()).optional(),
+    plugins: z.object({}).strict().optional(),
   });
 
   return templateSettingsSchema.merge(pluginShape);

--- a/packages/skaff-lib/src/core/generation/pipeline/pipeline-stages.ts
+++ b/packages/skaff-lib/src/core/generation/pipeline/pipeline-stages.ts
@@ -14,7 +14,7 @@ import type { GitService } from "../../infra/git-service";
 import type { GeneratorOptions } from "../template-generation-types";
 import type { ProjectSettingsSynchronizer } from "../ProjectSettingsSynchronizer";
 import type { AutoInstantiationCoordinator } from "./AutoInstantiationCoordinator";
-import type { PipelineStage } from "./pipeline-runner";
+import type { PipelinePhase, PipelineStage } from "./pipeline-runner";
 import { PipelineRunner } from "./pipeline-runner";
 import type { SideEffectCoordinator } from "./SideEffectCoordinator";
 import type { TargetPathResolver } from "./TargetPathResolver";
@@ -62,7 +62,11 @@ export const createProjectCreationPipeline = (
 export class ContextSetupStage
   implements PipelineStage<TemplateInstantiationPipelineContext>
 {
+  public readonly key = "context-setup";
   public readonly name = "context-setup";
+  public readonly phase: PipelinePhase = "setup";
+  public readonly priority = 10;
+  public readonly source = "core";
 
   constructor(
     private readonly pipelineContext: TemplatePipelineContext,
@@ -118,7 +122,11 @@ export class ContextSetupStage
 export class TemplateValidationStage
   implements PipelineStage<TemplateInstantiationPipelineContext>
 {
+  public readonly key = "template-validation";
   public readonly name = "template-validation";
+  public readonly phase: PipelinePhase = "configure";
+  public readonly priority = 20;
+  public readonly source = "core";
 
   constructor(private readonly projectSettings: ProjectSettings) { }
 
@@ -198,7 +206,11 @@ export class TemplateValidationStage
 export class RenderStage
   implements PipelineStage<TemplateInstantiationPipelineContext>
 {
+  public readonly key = "render";
   public readonly name = "render";
+  public readonly phase: PipelinePhase = "run";
+  public readonly priority = 30;
+  public readonly source = "core";
 
   constructor(private readonly fileMaterializer: TemplateFileMaterializer) { }
 
@@ -224,7 +236,11 @@ export class RenderStage
 export class SideEffectsStage
   implements PipelineStage<TemplateInstantiationPipelineContext>
 {
+  public readonly key = "side-effects";
   public readonly name = "side-effects";
+  public readonly phase: PipelinePhase = "run";
+  public readonly priority = 40;
+  public readonly source = "core";
 
   constructor(private readonly sideEffectCoordinator: SideEffectCoordinator) { }
 
@@ -250,7 +266,11 @@ export class SideEffectsStage
 export class PersistTemplateSettingsStage
   implements PipelineStage<TemplateInstantiationPipelineContext>
 {
+  public readonly key = "persist-template-settings";
   public readonly name = "persist-template-settings";
+  public readonly phase: PipelinePhase = "finalize";
+  public readonly priority = 50;
+  public readonly source = "core";
 
   constructor(
     private readonly projectSettingsSynchronizer: ProjectSettingsSynchronizer,
@@ -290,7 +310,11 @@ export class PersistTemplateSettingsStage
 export class AutoInstantiationStage
   implements PipelineStage<TemplateInstantiationPipelineContext>
 {
+  public readonly key = "auto-instantiation";
   public readonly name = "auto-instantiation";
+  public readonly phase: PipelinePhase = "after";
+  public readonly priority = 60;
+  public readonly source = "core";
 
   constructor(private readonly autoInstantiationCoordinator: AutoInstantiationCoordinator) { }
 
@@ -335,7 +359,11 @@ export class AutoInstantiationStage
 export class TargetPathStage
   implements PipelineStage<TemplateInstantiationPipelineContext>
 {
+  public readonly key = "target-path";
   public readonly name = "target-path";
+  public readonly phase: PipelinePhase = "after";
+  public readonly priority = 70;
+  public readonly source = "core";
 
   constructor(
     private readonly targetPathResolver: TargetPathResolver,
@@ -374,7 +402,11 @@ export class TargetPathStage
 export class ProjectSetupStage
   implements PipelineStage<ProjectCreationPipelineContext>
 {
+  public readonly key = "project-setup";
   public readonly name = "project-setup";
+  public readonly phase: PipelinePhase = "setup";
+  public readonly priority = 10;
+  public readonly source = "core";
 
   constructor(
     private readonly options: GeneratorOptions,
@@ -453,7 +485,11 @@ export class ProjectSetupStage
 export class ProjectRenderingStage
   implements PipelineStage<ProjectCreationPipelineContext>
 {
+  public readonly key = "project-render";
   public readonly name = "project-render";
+  public readonly phase: PipelinePhase = "run";
+  public readonly priority = 30;
+  public readonly source = "core";
 
   constructor(private readonly fileMaterializer: TemplateFileMaterializer) { }
 
@@ -479,7 +515,11 @@ export class ProjectRenderingStage
 export class ProjectSideEffectsStage
   implements PipelineStage<ProjectCreationPipelineContext>
 {
+  public readonly key = "project-side-effects";
   public readonly name = "project-side-effects";
+  public readonly phase: PipelinePhase = "run";
+  public readonly priority = 40;
+  public readonly source = "core";
 
   constructor(private readonly sideEffectCoordinator: SideEffectCoordinator) { }
 
@@ -505,7 +545,11 @@ export class ProjectSideEffectsStage
 export class ProjectAutoInstantiationStage
   implements PipelineStage<ProjectCreationPipelineContext>
 {
+  public readonly key = "project-auto-instantiation";
   public readonly name = "project-auto-instantiation";
+  public readonly phase: PipelinePhase = "after";
+  public readonly priority = 60;
+  public readonly source = "core";
 
   constructor(private readonly autoInstantiationCoordinator: AutoInstantiationCoordinator) { }
 

--- a/packages/skaff-lib/src/core/generation/template-generation-types.ts
+++ b/packages/skaff-lib/src/core/generation/template-generation-types.ts
@@ -1,17 +1,11 @@
 import { ProjectSettings } from "@timonteutelink/template-types-lib";
 
 import type { Template } from "../templates/Template";
-import type { GitService } from "../infra/git-service";
 import type {
   ProjectCreationPipelineContext,
   TemplateInstantiationPipelineContext,
 } from "./pipeline/pipeline-stages";
-import { TemplatePipelineContext } from "./pipeline/TemplatePipelineContext";
-import { TargetPathResolver } from "./pipeline/TargetPathResolver";
-import { TemplateFileMaterializer } from "./pipeline/TemplateFileMaterializer";
-import { SideEffectCoordinator } from "./pipeline/SideEffectCoordinator";
-import { AutoInstantiationCoordinator } from "./pipeline/AutoInstantiationCoordinator";
-import { ProjectSettingsSynchronizer } from "./ProjectSettingsSynchronizer";
+import { HelperDelegate } from "handlebars";
 import type { PipelineBuilder, PipelineStage } from "./pipeline/pipeline-runner";
 
 export interface GeneratorOptions {
@@ -48,13 +42,7 @@ export interface TemplateGenerationPipelineOverrides {
 export interface TemplatePipelinePluginContext {
   options: GeneratorOptions;
   rootTemplate: Template;
-  pipelineContext: TemplatePipelineContext;
-  targetPathResolver: TargetPathResolver;
-  fileMaterializer: TemplateFileMaterializer;
-  sideEffectCoordinator: SideEffectCoordinator;
-  autoInstantiationCoordinator: AutoInstantiationCoordinator;
-  projectSettingsSynchronizer: ProjectSettingsSynchronizer;
-  gitService: GitService;
+  registerHandlebarHelpers: (helpers: Record<string, HelperDelegate>) => void;
 }
 
 /**

--- a/packages/skaff-lib/src/index.ts
+++ b/packages/skaff-lib/src/index.ts
@@ -11,6 +11,8 @@ export {
   PipelineBuilder,
   PipelineRunner,
   type PipelineStage,
+  type PipelinePhase,
+  DEFAULT_PIPELINE_PHASE_ORDER,
 } from "./core/generation/pipeline/pipeline-runner";
 export {
   buildDefaultProjectCreationStages,

--- a/packages/template-types-lib/src/types/plugin-settings-schemas.ts
+++ b/packages/template-types-lib/src/types/plugin-settings-schemas.ts
@@ -1,12 +1,12 @@
 import { z } from "zod";
 
-export const pluginSystemSettingsSchema = z.object({}).passthrough();
+export const pluginSystemSettingsSchema = z.object({}).strict();
 
 export const pluginAdditionalTemplateSettingsSchema = z
   .object({})
-  .passthrough();
+  .strict();
 
-export const pluginFinalSettingsSchema = z.object({}).passthrough();
+export const pluginFinalSettingsSchema = z.object({}).strict();
 
 export type PluginSystemSettings = z.infer<typeof pluginSystemSettingsSchema>;
 export type PluginAdditionalTemplateSettings = z.infer<

--- a/packages/template-types-lib/src/types/project-settings-types.ts
+++ b/packages/template-types-lib/src/types/project-settings-types.ts
@@ -15,7 +15,15 @@ export const instantiatedTemplateSchema = z.object({
   lastMigration: z.string().optional(),
 
   plugins: z
-    .record(z.string(), z.record(z.string(), z.unknown()))
+    .record(
+      z.string(),
+      z
+        .object({
+          version: z.string(),
+          settings: z.unknown(),
+        })
+        .strict(),
+    )
     .optional(),
 });
 


### PR DESCRIPTION
## Summary
- introduce explicit plugin manifests with schema declarations and versioned settings
- enforce deterministic pipeline composition with keyed stages and logging
- tighten plugin schema validation, helper registration, and sample plugin modules

## Testing
- bun run test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f2927f1c883259b52c26893caf274)