### PR TITLE
Add deterministic plugin ordering metadata and stable lifecycle ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Templates may also include tasks, linting and formatting setups so that your new
   activates a plugin when that specific template is being generated.
 - A shared loader exported from `@timonteutelink/skaff-lib` (`loadPluginsForTemplate`) resolves these modules relative to the
   template repository's `package.json`, making the same discovery rules available to both the CLI and the Web UI.
+- Plugin declarations can include explicit `dependsOn` and `weight` hints to stabilize hook execution order across runs when
+  multiple plugins are enabled.
 - Plugins target the `TemplateGenerationPlugin` interface, which receives a `PipelineBuilder` seeded with the default stages so
   they can inject, replace or remove steps while keeping the base pipeline intact and deterministic when no plugins load.
 - Plugins can persist namespaced data under `instantiatedTemplates.<id>.plugins.<pluginName>` using the shared

--- a/packages/skaff-lib/src/core/plugins/plugin-lifecycle.ts
+++ b/packages/skaff-lib/src/core/plugins/plugin-lifecycle.ts
@@ -6,6 +6,7 @@ import type {
   PluginErrorContext,
   PluginGenerationResult,
 } from "./plugin-types";
+import { sortLoadedPluginsForLifecycle } from "./plugin-types";
 
 /**
  * Manages the lifecycle of loaded plugins.
@@ -18,7 +19,7 @@ export class PluginLifecycleManager {
   private readonly activatedPlugins: Set<string> = new Set();
 
   constructor(plugins: LoadedTemplatePlugin[]) {
-    this.plugins = plugins;
+    this.plugins = sortLoadedPluginsForLifecycle(plugins);
   }
 
   /**

--- a/packages/skaff-lib/tests/plugin-ordering.test.ts
+++ b/packages/skaff-lib/tests/plugin-ordering.test.ts
@@ -1,0 +1,38 @@
+import type { LoadedTemplatePlugin } from "../src/core/plugins/plugin-types";
+import { sortLoadedPluginsForLifecycle } from "../src/core/plugins/plugin-types";
+
+function createPlugin(
+  name: string,
+  reference: LoadedTemplatePlugin["reference"],
+): LoadedTemplatePlugin {
+  return {
+    name,
+    version: "1.0.0",
+    reference,
+    module: {} as LoadedTemplatePlugin["module"],
+  };
+}
+
+describe("plugin ordering", () => {
+  it("stabilizes ordering with weights and dependencies", () => {
+    const plugins = [
+      createPlugin("plugin-c", { module: "plugin-c" }),
+      createPlugin("plugin-b", {
+        module: "plugin-b",
+        dependsOn: ["plugin-a"],
+      }),
+      createPlugin("plugin-a", { module: "plugin-a" }),
+      createPlugin("plugin-d", { module: "plugin-d", weight: -10 }),
+    ];
+
+    const order = sortLoadedPluginsForLifecycle(plugins).map(
+      (plugin) => plugin.name,
+    );
+    const repeatedOrder = sortLoadedPluginsForLifecycle(plugins).map(
+      (plugin) => plugin.name,
+    );
+
+    expect(order).toEqual(["plugin-d", "plugin-c", "plugin-a", "plugin-b"]);
+    expect(repeatedOrder).toEqual(order);
+  });
+});

--- a/packages/template-types-lib/README.md
+++ b/packages/template-types-lib/README.md
@@ -7,7 +7,7 @@ This package provides the shared TypeScript types and Zod schemas used when auth
 - **`TemplateConfig`** – Strongly typed metadata describing a template (name, author, spec version, etc.).
 - **`TemplateConfigModule`** – The contract every `templateConfig.ts` module implements to expose settings schemas, helpers, and lifecycle hooks.
 - **`projectSettingsSchema`** – Zod schema (with matching `ProjectSettings` type) for validating the generated project's global metadata and instantiated templates.
-- **`TemplatePluginConfig`** – Declares the plugin module specifier, optional export name, and options passed to Skaff's plugin loader when a template opts into plugins.
+- **`TemplatePluginConfig`** – Declares the plugin module specifier, optional export name, dependency/weight ordering hints, and options passed to Skaff's plugin loader when a template opts into plugins.
 
 ## Usage
 
@@ -53,8 +53,9 @@ export default templateModule;
 
 Template authors can opt into plugins by adding a `plugins` array to the exported `TemplateConfigModule`. Each entry is a
 `TemplatePluginConfig` describing the module specifier (resolved from the template repository's `package.json`), the export to
-load (defaults to `default`), and optional plugin-specific options. The Skaff library exposes a shared loader that the CLI and
-Web UI reuse to import these modules at runtime, ensuring plugins only activate for templates that explicitly list them.
+load (defaults to `default`), optional dependency/weight hints to stabilize execution order, and optional plugin-specific
+options. The Skaff library exposes a shared loader that the CLI and Web UI reuse to import these modules at runtime, ensuring
+plugins only activate for templates that explicitly list them.
 
 Plugins can also persist namespaced data inside `templateSettings.json` under
 `instantiatedTemplates[].plugins[pluginName]`, letting runtime hooks store and retrieve state without colliding with template

--- a/packages/template-types-lib/src/types/template-config-types.ts
+++ b/packages/template-types-lib/src/types/template-config-types.ts
@@ -206,6 +206,18 @@ export type TemplatePluginConfig = {
    * Arbitrary configuration passed to the plugin factory (if it exposes one).
    */
   options?: unknown;
+
+  /**
+   * Ordered list of plugin names or module specifiers that must run before this plugin.
+   * Use this to declare explicit dependencies when plugin execution order matters.
+   */
+  dependsOn?: string[];
+
+  /**
+   * Weight to influence plugin ordering when no dependencies apply.
+   * Lower weights run earlier; higher weights run later.
+   */
+  weight?: number;
 };
 
 export interface TemplateMigration {


### PR DESCRIPTION
### Motivation

- Ensure plugin lifecycle hooks and pipeline injections run in a deterministic order when multiple plugins are enabled.  
- Allow template authors to express explicit plugin dependencies and provide lightweight ordering hints to avoid nondeterministic behavior.  
- Prevent flakiness in plugin ordering across runs and improve reproducibility of template generation.  

### Description

- Add `dependsOn?: string[]` and `weight?: number` to `TemplatePluginConfig` and propagate them into `NormalizedTemplatePluginConfig`.  
- Implement `sortLoadedPluginsForLifecycle` which performs a dependency-aware, stable ordering using a topological-like walk with `weight` and original index as tiebreakers.  
- Use the stable sorter in `loadPluginsForTemplate` to return plugins in the computed order and invoke `onLoad` hooks in that same stable order, and initialize `PluginLifecycleManager` with the sorted list.  
- Update `README.md` and `packages/template-types-lib/README.md` documentation and add a unit test `packages/skaff-lib/tests/plugin-ordering.test.ts` that asserts stable, repeatable ordering.  

### Testing

- Added unit test `packages/skaff-lib/tests/plugin-ordering.test.ts` which verifies ordering stability and dependency/weight handling.  
- Attempted to run the full test suite with `cd packages/skaff-lib && bun run test`, but the test command failed because `jest` is not available in the execution environment.  
- No CI tests were executed in this environment due to the missing test runner, so the new test has not been validated here.  
- Manual inspection and local type checks were performed as part of the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946e9c2bef883258a950e805c8329a8)