### PR TITLE
Require pre-registered plugins for template loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,9 @@ Templates may also include tasks, linting and formatting setups so that your new
 
 - Each `templateConfig.ts` can declare an optional `plugins` array describing plugin module specifiers and options. Skaff only
   activates a plugin when that specific template is being generated.
-- A shared loader exported from `@timonteutelink/skaff-lib` (`loadPluginsForTemplate`) resolves these modules relative to the
-  template repository's `package.json`, making the same discovery rules available to both the CLI and the Web UI.
+- A shared loader exported from `@timonteutelink/skaff-lib` (`loadPluginsForTemplate`) activates only **pre-registered** plugins.
+  Environments must register plugins at startup (CLI via oclif, Web via build-time registry, or library consumers via
+  `registerPluginModules`) before templates can use them.
 - Plugin declarations can include explicit `dependsOn` and `weight` hints to stabilize hook execution order across runs when
   multiple plugins are enabled.
 - Plugins target the `TemplateGenerationPlugin` interface, which receives a `PipelineBuilder` seeded with the default stages so

--- a/apps/cli/src/base-command.ts
+++ b/apps/cli/src/base-command.ts
@@ -1,6 +1,7 @@
 import { Command, Flags } from '@oclif/core';
 
 import { DEFAULT_FORMAT, Format, printFormatted } from './utils/cli-utils.js';
+import { registerInstalledPluginModules } from './utils/plugin-manager.js';
 
 export default abstract class BaseCommand extends Command {
   /** Global flags available to every command */
@@ -24,5 +25,9 @@ export default abstract class BaseCommand extends Command {
     const { flags } = await this.parse();
     printFormatted(data, (flags.format ?? DEFAULT_FORMAT) as Format);
   }
-}
 
+  protected async init(): Promise<void> {
+    await super.init();
+    await registerInstalledPluginModules(this.config);
+  }
+}

--- a/apps/web/scripts/generate-plugin-registry.ts
+++ b/apps/web/scripts/generate-plugin-registry.ts
@@ -239,7 +239,7 @@ async function discoverPlugins(): Promise<DiscoveredPlugin[]> {
  */
 function generateRegistryFile(plugins: DiscoveredPlugin[]): string {
   const imports = plugins
-    .map((p, i) => `import plugin${i} from "${p.importPath}";`)
+    .map((p, i) => `import * as plugin${i} from "${p.importPath}";`)
     .join("\n");
 
   const registryEntries = plugins
@@ -278,12 +278,12 @@ function generateRegistryFile(plugins: DiscoveredPlugin[]): string {
  * Generated: ${new Date().toISOString()}
  */
 
-import type { SkaffPluginModule, PluginTrustLevel } from "@timonteutelink/skaff-lib";
+import type { PluginTrustLevel } from "@timonteutelink/skaff-lib";
 
 ${imports}
 
 export interface InstalledPluginEntry {
-  module: SkaffPluginModule;
+  module: Record<string, unknown>;
   packageName: string;
   version: string;
   trustLevel: PluginTrustLevel;
@@ -314,7 +314,7 @@ ${manifestEntries}
 /**
  * Get a plugin by its manifest name.
  */
-export function getInstalledPlugin(name: string): SkaffPluginModule | null {
+export function getInstalledPlugin(name: string): Record<string, unknown> | null {
   return INSTALLED_PLUGINS[name]?.module ?? null;
 }
 

--- a/apps/web/src/app/actions/instantiate.ts
+++ b/apps/web/src/app/actions/instantiate.ts
@@ -1,8 +1,11 @@
 "use server";
 import { findProject } from "@/lib/server-utils";
+import { ensureWebPluginsRegistered } from "@/lib/plugins/register-plugins";
 import * as tempLib from "@timonteutelink/skaff-lib";
 import { getConfig, NewTemplateDiffResult, ParsedFile, ProjectCreationResult, projectSearchPathKey, Result } from "@timonteutelink/skaff-lib";
 import { UserTemplateSettings } from "@timonteutelink/template-types-lib";
+
+ensureWebPluginsRegistered();
 
 export async function createNewProject(
   projectRepositoryName: string,

--- a/apps/web/src/app/actions/project.ts
+++ b/apps/web/src/app/actions/project.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { findProject, listProjects } from "@/lib/server-utils";
+import { ensureWebPluginsRegistered } from "@/lib/plugins/register-plugins";
 import * as tempLib from "@timonteutelink/skaff-lib";
 import {
   ProjectDTO,
@@ -8,6 +9,8 @@ import {
   createTemplateView,
 } from "@timonteutelink/skaff-lib";
 import { createReadonlyProjectContext } from "@timonteutelink/template-types-lib";
+
+ensureWebPluginsRegistered();
 
 export async function retrieveProjectSearchPaths(): Promise<
   { id: string; path: string }[]

--- a/apps/web/src/lib/plugins/generated-plugin-registry.ts
+++ b/apps/web/src/lib/plugins/generated-plugin-registry.ts
@@ -10,12 +10,12 @@
  * Generated: 2025-12-16T03:37:02.995Z
  */
 
-import type { SkaffPluginModule, PluginTrustLevel } from "@timonteutelink/skaff-lib";
+import type { PluginTrustLevel } from "@timonteutelink/skaff-lib";
 
 
 
 export interface InstalledPluginEntry {
-  module: SkaffPluginModule;
+  module: Record<string, unknown>;
   packageName: string;
   version: string;
   trustLevel: PluginTrustLevel;
@@ -46,7 +46,7 @@ export const PLUGIN_MANIFEST: PluginManifestEntry[] = [
 /**
  * Get a plugin by its manifest name.
  */
-export function getInstalledPlugin(name: string): SkaffPluginModule | null {
+export function getInstalledPlugin(name: string): Record<string, unknown> | null {
   return INSTALLED_PLUGINS[name]?.module ?? null;
 }
 

--- a/apps/web/src/lib/plugins/register-plugins.ts
+++ b/apps/web/src/lib/plugins/register-plugins.ts
@@ -1,0 +1,18 @@
+import { registerPluginModules } from "@timonteutelink/skaff-lib";
+
+import { INSTALLED_PLUGINS } from "./generated-plugin-registry";
+
+let registered = false;
+
+export function ensureWebPluginsRegistered(): void {
+  if (registered) return;
+  const entries = Object.values(INSTALLED_PLUGINS).map((entry) => ({
+    moduleExports: entry.module,
+    packageName: entry.packageName,
+  }));
+
+  if (entries.length > 0) {
+    registerPluginModules(entries);
+  }
+  registered = true;
+}


### PR DESCRIPTION
### Motivation
- Restrict plugin activation to a small, explicit set of installation mechanisms and ensure plugins are loaded globally at startup rather than being dynamically bundled per-template. 
- Improve security by preventing templates from dynamically resolving, bundling and executing arbitrary plugin code from template repos. 
- Support three sanctioned plugin installation flows: oclif-installed CLI plugins, web build-time registry (e.g. `SKAFF_PLUGINS`), and programmatic registration for library consumers. 
- Make plugin surface stable so future extensions can safely change global behaviours without per-template code loading.

### Description
- Reworked `loadPluginsForTemplate` to use pre-registered plugin modules instead of resolving/bundling template-local modules, and added `registerPluginModules` / `clearRegisteredPluginModules` to the plugin loader API. 
- CLI now registers installed oclif plugins at startup via a new `registerInstalledPluginModules` helper called from `BaseCommand.init()`. 
- Web changed to generate a static plugin registry that imports plugin namespaces (`apps/web/scripts/generate-plugin-registry.ts`) and a small runtime helper (`apps/web/src/lib/plugins/register-plugins.ts`) that registers those modules at server startup, and the web stage loader updated to read from the static registry. 
- Tests updated: `packages/skaff-lib/tests/plugin-loader.test.ts` now imports/registers fake plugin module namespaces via `registerPluginModules` and clears registration after each case; `README.md` updated to document the pre-registration requirement.

### Testing
- Ran the library test command: `cd packages/skaff-lib && bun run test` to exercise plugin loader tests, which started but failed early. 
- Test run failed with multiple suites reporting `Cannot find module 'ses'` indicating the SES runtime dependency is not available in the test environment. 
- The new plugin-loader unit tests were updated to register modules programmatically (they are present but full test run did not complete due to the SES import error). 
- No other automated test suites were executed successfully in this run due to the sandbox dependency failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949748a5b988325bd7615f0d0c67269)