### PR TITLE
Add local test template repository for manual validation

### DIFF
--- a/examples/test-templates/test-template-repo/DEV_NOTES.md
+++ b/examples/test-templates/test-template-repo/DEV_NOTES.md
@@ -1,0 +1,19 @@
+# Local test template repo (manual testing)
+
+The Skaff template loader scans `<path>/templates` for template repositories, so
+point `TEMPLATE_DIR_PATHS` at the repo root that contains the `templates/`
+folder. See:
+
+- `packages/skaff-lib/src/repositories/root-template-repository.ts`
+- `packages/skaff-lib/src/lib/config.ts`
+
+## Manual testing flow
+
+```bash
+export TEMPLATE_DIR_PATHS=/workspace/skaff/templates/test-templates
+skaff project new demo-project test_template
+```
+
+`/workspace/skaff/templates/test-templates` is a convenience symlink to this
+repo (`examples/test-templates/test-template-repo`), so the CLI can resolve the
+local template without cloning a remote repository.

--- a/examples/test-templates/test-template-repo/templates/test-template/files/testlocation/README.md
+++ b/examples/test-templates/test-template-repo/templates/test-template/files/testlocation/README.md
@@ -1,0 +1,1 @@
+{{test_string}}

--- a/examples/test-templates/test-template-repo/templates/test-template/templateConfig.ts
+++ b/examples/test-templates/test-template-repo/templates/test-template/templateConfig.ts
@@ -1,0 +1,117 @@
+import z from "zod";
+import {
+  TemplateConfig,
+  TemplateConfigModule,
+} from "@timonteutelink/template-types-lib";
+
+const templateSettingsSchema = z.object({
+  test_boolean: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe("A boolean to test with"),
+  test_string: z
+    .string()
+    .default("Whats 9 + 10?")
+    .describe("A string to test with"),
+  test_number: z
+    .number()
+    .min(10)
+    .max(100)
+    .default(21)
+    .describe("A number to test with"),
+  test_object: z.object({
+    test_array: z
+      .array(
+        z.object({
+          test_string_in_array: z
+            .string()
+            .min(5)
+            .default("Very nice")
+            .describe("A string in an array to test with"),
+        }),
+      )
+      .min(2)
+      .default([
+        { test_string_in_array: "banananananana" },
+        { test_string_in_array: "banana" },
+      ])
+      .describe("An array to test with"),
+    more_stuff: z
+      .enum(["option1", "option2", "option3"])
+      .default("option2")
+      .describe("An enum to test with"),
+  }),
+});
+
+const coolifyHelper = (str: string) =>
+  str
+    .split("")
+    .map((char, index) =>
+      index % 2 === 0 ? char.toUpperCase() : char.toLowerCase(),
+    )
+    .join("");
+
+const templateFinalSettingsSchema = templateSettingsSchema;
+
+const templateConfig: TemplateConfig = {
+  name: "test_template",
+  description: "A template to test all features",
+  author: "Timon Teutelink",
+  specVersion: "1.0.0",
+  isRootTemplate: true,
+};
+
+const templateConfigModule: TemplateConfigModule<{}, typeof templateSettingsSchema> = {
+  templateConfig,
+  targetPath: ".",
+  templateSettingsSchema,
+  templateFinalSettingsSchema,
+  mapFinalSettings: ({ templateSettings }) => ({
+    ...templateSettings,
+  }),
+
+  autoInstantiatedSubtemplates: [
+    {
+      subTemplateName: "test_stuff",
+      mapSettings: (finalSettings) => ({
+        answer:
+          finalSettings.test_string === "Whats 9 + 10?"
+            ? String(finalSettings.test_number)
+            : "42",
+      }),
+    },
+  ],
+
+  redirects: [
+    {
+      from: "testlocation/README.md",
+      to: "README.md",
+    },
+  ],
+
+  sideEffects: [
+    {
+      filePath: "README.md",
+      transform: ({ templateSettings, existingContents }) => {
+        const nice = templateSettings.test_boolean ? "nice" : "not nice";
+        const baseContents = existingContents ?? "";
+        return `${baseContents}\n# This is a ${nice} template`;
+      },
+    },
+  ],
+
+  assertions: (settings) => settings.test_boolean,
+
+  commands: [
+    {
+      title: "Test Command",
+      description: "A test command that does nothing",
+      command: "echo 'This is a test command'",
+    },
+  ],
+
+  handlebarHelpers: { coolifyHelper },
+};
+
+export default templateConfigModule;

--- a/examples/test-templates/test-template-repo/templates/test-template/test-subtemplate-1/teststuff/files/nice.txt
+++ b/examples/test-templates/test-template-repo/templates/test-template/test-subtemplate-1/teststuff/files/nice.txt
@@ -1,0 +1,1 @@
+{{markdown_answer}}

--- a/examples/test-templates/test-template-repo/templates/test-template/test-subtemplate-1/teststuff/templateConfig.ts
+++ b/examples/test-templates/test-template-repo/templates/test-template/test-subtemplate-1/teststuff/templateConfig.ts
@@ -1,0 +1,36 @@
+import z from "zod";
+import {
+  TemplateConfig,
+  TemplateConfigModule,
+} from "@timonteutelink/template-types-lib";
+
+const templateSettingsSchema = z.object({
+  answer: z.string().default("21").describe("Whats 9 + 10?"),
+});
+
+const templateFinalSettingsSchema = z.object({
+  markdown_answer: z.string(),
+});
+
+const templateConfig: TemplateConfig = {
+  name: "test_stuff",
+  description: "Testing stuff",
+  author: "Timon Teutelink",
+  specVersion: "1.0.0",
+};
+
+const templateConfigModule: TemplateConfigModule<
+  {},
+  typeof templateSettingsSchema,
+  typeof templateFinalSettingsSchema
+> = {
+  templateConfig,
+  targetPath: "./otherlocation",
+  templateSettingsSchema,
+  templateFinalSettingsSchema,
+  mapFinalSettings: ({ templateSettings }) => ({
+    markdown_answer: `The answer to 'Whats 9 + 10?' is **${templateSettings.answer}**`,
+  }),
+};
+
+export default templateConfigModule;

--- a/templates/test-templates
+++ b/templates/test-templates
@@ -1,1 +1,0 @@
-../examples/test-templates/test-template-repo

--- a/templates/test-templates
+++ b/templates/test-templates
@@ -1,0 +1,1 @@
+../examples/test-templates/test-template-repo


### PR DESCRIPTION
### Motivation

- Provide a lightweight, local template repository to exercise root templates and subtemplate wiring without cloning a remote repo.
- Mirror the structure expected by `RootTemplateRepository` so the loader can pick up local templates under `<path>/templates`.
- Keep the vendor copy minimal by trimming large assets while keeping schema, helpers and side-effects.
- Add a simple manual testing note so developers can verify the loader behavior quickly.

### Description

- Added `examples/test-templates/test-template-repo` containing `templates/test-template/templateConfig.ts`, `templates/test-template/files/testlocation/README.md`, and a small subtemplate at `templates/test-template/test-subtemplate-1/teststuff` with `templateConfig.ts` and `files/nice.txt`.
- Set `isRootTemplate: true` in the root `templateConfig.ts` to ensure the template appears in root template listings.
- Added `examples/test-templates/DEV_NOTES.md` documenting the manual test flow and showing `TEMPLATE_DIR_PATHS=/workspace/skaff/templates/test-templates` usage and `skaff project new ...` invocation.
- Created a convenience symlink `templates/test-templates` -> `../examples/test-templates/test-template-repo` so the CLI can resolve the local template path without remote cloning.

### Testing

- Ran `bun install` at the repo root which completed successfully.
- Built the types package with `cd packages/template-types-lib && bun run build` which succeeded.
- Ran the library test suite with `cd packages/skaff-lib && bun run test` which started successfully but the run failed due to plugin-loader tests reporting an invalid template plugin context missing `isDetachedSubtreeRoot` and `isLocal` fields.
- Created and committed the new files under `examples/test-templates` and the `templates/test-templates` symlink (commit message: "Add local test template repo").

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b0ddfb5d0832597dfc138b2c9911d)