### PR TITLE
Enforce plugin required settings and run init/finalize stages in CLI/Web flows

### DIFF
--- a/examples/plugins/plugin-greeter-cli/src/index.ts
+++ b/examples/plugins/plugin-greeter-cli/src/index.ts
@@ -3,9 +3,9 @@ import type {
   CliTemplateStage,
   PluginCliCommand,
 } from "@timonteutelink/skaff-lib";
-import { GREETER_PLUGIN_NAME } from "@timonteutelink/skaff-plugin-greeter-types";
+import { GREETER_PLUGIN_NAME } from "../../plugin-greeter-types/src/index";
 
-type GreeterStageState = { disabled?: boolean };
+type GreeterStageState = { disabled?: boolean; message?: string };
 
 const greeterCliCommand: PluginCliCommand = {
   name: "greet",
@@ -39,6 +39,25 @@ const greeterCliBeforeStage: CliTemplateStage<GreeterStageState> = {
   },
 };
 
+const greeterCliInitStage: CliTemplateStage<GreeterStageState> = {
+  id: "greeter-cli-init",
+  placement: "init",
+  async run({ prompts, setStageState }) {
+    const message = await prompts.input({
+      message: "Enter a greeting message for the greeter plugin",
+      default: "Hello from greeter!",
+    });
+    setStageState({ message });
+    return {
+      plugins: {
+        [GREETER_PLUGIN_NAME]: {
+          message,
+        },
+      },
+    };
+  },
+};
+
 const greeterCliAfterStage: CliTemplateStage<GreeterStageState> = {
   id: "greeter-cli-after",
   placement: "after-settings",
@@ -49,9 +68,25 @@ const greeterCliAfterStage: CliTemplateStage<GreeterStageState> = {
   },
 };
 
+const greeterCliFinalizeStage: CliTemplateStage<GreeterStageState> = {
+  id: "greeter-cli-finalize",
+  placement: "finalize",
+  async run({ currentSettings }) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `👋 finalize: ${JSON.stringify(currentSettings?.plugins ?? {})}`,
+    );
+  },
+};
+
 const greeterCliContribution: CliPluginContribution = {
   commands: [greeterCliCommand],
-  templateStages: [greeterCliBeforeStage, greeterCliAfterStage],
+  templateStages: [
+    greeterCliInitStage,
+    greeterCliBeforeStage,
+    greeterCliAfterStage,
+    greeterCliFinalizeStage,
+  ],
 };
 
 const greeterCliPlugin = {

--- a/examples/plugins/plugin-greeter-web/src/index.tsx
+++ b/examples/plugins/plugin-greeter-web/src/index.tsx
@@ -3,9 +3,47 @@ import type {
   WebTemplateStage,
 } from "@timonteutelink/skaff-lib";
 import React, { useState } from "react";
-import { GREETER_PLUGIN_NAME } from "@timonteutelink/skaff-plugin-greeter-types";
+import { GREETER_PLUGIN_NAME } from "../../plugin-greeter-types/src/index";
 
-type GreeterStageState = { disabled?: boolean };
+type GreeterStageState = { disabled?: boolean; message?: string };
+
+const greeterInitWebStage: WebTemplateStage<GreeterStageState> = {
+  id: "greeter-init",
+  placement: "init",
+  render: ({ onContinue, stageState, setStageState }) => {
+    const [message, setMessage] = useState(
+      typeof stageState?.message === "string"
+        ? stageState.message
+        : "Hello from greeter!",
+    );
+
+    return (
+      <div className="space-y-4 p-6 border rounded-md bg-white">
+        <h2 className="text-xl font-semibold">Greeter init</h2>
+        <p className="text-muted-foreground">
+          Provide the greeting message used by the greeter plugin.
+        </p>
+        <input
+          type="text"
+          className="w-full border rounded-md px-3 py-2"
+          value={message}
+          onChange={(event) => {
+            const next = event.target.value;
+            setMessage(next);
+            setStageState({ message: next });
+          }}
+        />
+        <button
+          type="button"
+          className="px-4 py-2 rounded-md bg-blue-600 text-white"
+          onClick={onContinue}
+        >
+          Continue
+        </button>
+      </div>
+    );
+  },
+};
 
 const greeterBeforeWebStage: WebTemplateStage<GreeterStageState> = {
   id: "greeter-before-settings",
@@ -62,6 +100,26 @@ const greeterAfterWebStage: WebTemplateStage<GreeterStageState> = {
   ),
 };
 
+const greeterFinalizeWebStage: WebTemplateStage<GreeterStageState> = {
+  id: "greeter-finalize",
+  placement: "finalize",
+  render: ({ onContinue, currentSettings }) => (
+    <div className="space-y-4 p-6 border rounded-md bg-white">
+      <h2 className="text-xl font-semibold">Greeter finalize</h2>
+      <p className="text-muted-foreground">
+        Final settings: {JSON.stringify(currentSettings?.plugins ?? {})}
+      </p>
+      <button
+        type="button"
+        className="px-4 py-2 rounded-md bg-blue-600 text-white"
+        onClick={onContinue}
+      >
+        Continue to diff
+      </button>
+    </div>
+  ),
+};
+
 const greeterWebContribution: WebPluginContribution = {
   getNotices: ({ templateCount }) => {
     return [
@@ -70,7 +128,12 @@ const greeterWebContribution: WebPluginContribution = {
         : "Greeter plugin is ready to welcome you in the UI.",
     ];
   },
-  templateStages: [greeterBeforeWebStage, greeterAfterWebStage],
+  templateStages: [
+    greeterInitWebStage,
+    greeterBeforeWebStage,
+    greeterAfterWebStage,
+    greeterFinalizeWebStage,
+  ],
 };
 
 const greeterWebPlugin = {

--- a/examples/plugins/plugin-greeter/src/index.ts
+++ b/examples/plugins/plugin-greeter/src/index.ts
@@ -130,9 +130,13 @@ const greeterPlugin = {
       input: true,
       output: true,
     },
+    requiredSettingsKeys: ["message"],
   },
   lifecycle: greeterLifecycle,
-  inputSchema: pluginInputSchema,
+  inputSchema: pluginInputSchema.extend({
+    message: z.string().optional(),
+    audience: z.string().optional(),
+  }),
   outputSchema: pluginOutputSchema.extend({
     message: z.string().optional(),
     audience: z.string().optional(),

--- a/examples/test-templates/test-template-repo/templates/test-template/templateConfig.ts
+++ b/examples/test-templates/test-template-repo/templates/test-template/templateConfig.ts
@@ -77,6 +77,12 @@ const templateConfigModule: TemplateConfigModule<{}, typeof templateSettingsSche
         greeting: "Hello from the test-template greeter!",
       },
     },
+    {
+      module: "@timonteutelink/skaff-plugin-greeter-cli",
+    },
+    {
+      module: "@timonteutelink/skaff-plugin-greeter-web",
+    },
   ],
 
   autoInstantiatedSubtemplates: [

--- a/packages/skaff-lib/jest.config.ts
+++ b/packages/skaff-lib/jest.config.ts
@@ -14,7 +14,7 @@ const config: Config = {
         jsc: {
           parser: {
             syntax: "typescript",
-            tsx: false,
+            tsx: true,
           },
         },
       },
@@ -23,8 +23,11 @@ const config: Config = {
   setupFiles: ["<rootDir>/tests/setup-env.ts"],
   moduleNameMapper: {
     "^ses$": "<rootDir>/tests/mocks/ses.ts",
+    "^react$": "<rootDir>/tests/mocks/react.ts",
     "^@timonteutelink/template-types-lib$":
       "<rootDir>/../template-types-lib/src/index.ts",
+    "^@timonteutelink/skaff-plugin-greeter-types$":
+      "<rootDir>/../../examples/plugins/plugin-greeter-types/src/index.ts",
     "^zod$": "<rootDir>/node_modules/zod",
   },
 

--- a/packages/skaff-lib/src/core/infra/sandbox-endowments.ts
+++ b/packages/skaff-lib/src/core/infra/sandbox-endowments.ts
@@ -235,6 +235,12 @@ export const SANDBOX_REACT_STUB = Object.freeze({
   useInsertionEffect: Object.freeze(() => {}),
 });
 
+const SANDBOX_REACT_JSX_RUNTIME_STUB = Object.freeze({
+  Fragment: "sandbox-fragment",
+  jsx: Object.freeze(() => null),
+  jsxs: Object.freeze(() => null),
+});
+
 /**
  * Gets the plugin-specific sandbox libraries.
  *
@@ -258,6 +264,7 @@ export function getPluginSandboxLibraries(): Readonly<Record<string, unknown>> {
   return Object.freeze({
     ...baseLibs,
     react: SANDBOX_REACT_STUB,
+    "react/jsx-runtime": SANDBOX_REACT_JSX_RUNTIME_STUB,
   });
 }
 

--- a/packages/skaff-lib/src/core/plugins/index.ts
+++ b/packages/skaff-lib/src/core/plugins/index.ts
@@ -4,3 +4,4 @@ export * from "./plugin-lifecycle";
 export * from "./plugin-compatibility";
 export * from "./plugin-trust";
 export * from "./template-view";
+export * from "./plugin-settings";

--- a/packages/skaff-lib/src/core/plugins/plugin-settings.ts
+++ b/packages/skaff-lib/src/core/plugins/plugin-settings.ts
@@ -1,0 +1,95 @@
+import { UserTemplateSettings } from "@timonteutelink/template-types-lib";
+
+import { Result } from "../../lib/types";
+import { LoadedTemplatePlugin } from "./plugin-types";
+
+export type MissingRequiredPluginSettings = {
+  pluginName: string;
+  keys: string[];
+};
+
+function getNestedValue(
+  settings: Record<string, unknown>,
+  path: string,
+): unknown {
+  const segments = path.split(".");
+  let current: unknown = settings;
+
+  for (const segment of segments) {
+    if (!current || typeof current !== "object") {
+      return undefined;
+    }
+    if (!(segment in (current as Record<string, unknown>))) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return current;
+}
+
+export function findMissingRequiredPluginSettings(
+  plugins: LoadedTemplatePlugin[] | undefined,
+  settings: UserTemplateSettings,
+): MissingRequiredPluginSettings[] {
+  if (!plugins?.length) {
+    return [];
+  }
+
+  const missing: MissingRequiredPluginSettings[] = [];
+  const pluginSettings =
+    typeof settings.plugins === "object" && settings.plugins
+      ? (settings.plugins as Record<string, unknown>)
+      : undefined;
+
+  for (const plugin of plugins) {
+    const requiredKeys = plugin.requiredSettingsKeys ?? [];
+    if (requiredKeys.length === 0) {
+      continue;
+    }
+
+    const entry = pluginSettings?.[plugin.name];
+    const pluginEntry =
+      entry && typeof entry === "object"
+        ? (entry as Record<string, unknown>)
+        : undefined;
+
+    const missingKeys = requiredKeys.filter((key) => {
+      if (!pluginEntry) {
+        return true;
+      }
+      return getNestedValue(pluginEntry, key) === undefined;
+    });
+
+    if (missingKeys.length > 0) {
+      missing.push({ pluginName: plugin.name, keys: missingKeys });
+    }
+  }
+
+  return missing;
+}
+
+export function formatMissingRequiredPluginSettings(
+  missing: MissingRequiredPluginSettings[],
+): string {
+  if (missing.length === 0) {
+    return "";
+  }
+
+  const details = missing
+    .map(({ pluginName, keys }) => `${pluginName}: ${keys.join(", ")}`)
+    .join("; ");
+  return `Missing required plugin settings: ${details}`;
+}
+
+export function validateRequiredPluginSettings(
+  plugins: LoadedTemplatePlugin[] | undefined,
+  settings: UserTemplateSettings,
+): Result<void> {
+  const missing = findMissingRequiredPluginSettings(plugins, settings);
+  if (missing.length === 0) {
+    return { data: undefined };
+  }
+
+  return { error: formatMissingRequiredPluginSettings(missing) };
+}

--- a/packages/skaff-lib/src/models/project.ts
+++ b/packages/skaff-lib/src/models/project.ts
@@ -14,6 +14,7 @@ import { resolveHardenedSandbox } from "../core/infra/hardened-sandbox";
 import { Template } from "./template";
 import { backendLogger } from "../lib";
 import z from "zod";
+import { validateRequiredPluginSettings } from "../core/plugins/plugin-settings";
 
 // Every project repository name inside a root project should be unique.
 // The root project can be uniquely identified by its repository name and author (and version).
@@ -142,6 +143,15 @@ export class Project {
       return {
         error: `Failed to parse user settings: ${parsedUserSettings?.error}`,
       };
+    }
+
+    const requiredPluginSettingsResult = validateRequiredPluginSettings(
+      options?.plugins,
+      parsedUserSettings.data,
+    );
+
+    if ("error" in requiredPluginSettingsResult) {
+      return requiredPluginSettingsResult;
     }
 
     let parentFinalSettings: FinalTemplateSettings | undefined;

--- a/packages/skaff-lib/tests/mocks/react.ts
+++ b/packages/skaff-lib/tests/mocks/react.ts
@@ -1,0 +1,8 @@
+export const useState = <T,>(initial: T): [T, (next: T) => void] => [
+  initial,
+  () => {},
+];
+
+const React = { useState };
+
+export default React;

--- a/packages/skaff-lib/tests/plugin-required-settings-integration.test.ts
+++ b/packages/skaff-lib/tests/plugin-required-settings-integration.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import z from "zod";
+
+import { Project } from "../src/models/project";
+import type { LoadedTemplatePlugin } from "../src/core/plugins";
+import { createTestTemplate } from "./helpers/template-fixtures";
+
+describe("project settings validation for required plugin keys", () => {
+  jest.setTimeout(30000);
+  it("fails when required plugin settings are missing", async () => {
+    const { template } = await createTestTemplate({
+      name: "required_plugin_template",
+      settingsFields: { name: { type: "string", defaultValue: "demo" } },
+      templateConfig: { specVersion: "1.0.0" },
+      mapFinalSettingsBody:
+        "({ templateSettings }: { templateSettings: { name: string } }) => templateSettings",
+    });
+
+    const plugin = {
+      reference: { module: "required-plugin" },
+      module: {
+        manifest: {
+          name: "required-plugin",
+          version: "0.0.0",
+          capabilities: ["template"],
+          supportedHooks: { template: [], cli: [], web: [] },
+          schemas: { input: true, output: true },
+          requiredSettingsKeys: ["message"],
+        },
+      },
+      name: "required-plugin",
+      version: "0.0.0",
+      requiredSettingsKeys: ["message"],
+      inputSchema: z.object({ message: z.string() }),
+      outputSchema: z.object({ message: z.string() }),
+    } satisfies LoadedTemplatePlugin;
+
+    const result = Project.getFinalTemplateSettings(
+      template,
+      {
+        projectRepositoryName: "demo",
+        projectAuthor: "Tester",
+        rootTemplateName: template.config.templateConfig.name,
+        instantiatedTemplates: [],
+      },
+      { name: "demo", plugins: { "required-plugin": {} } },
+      undefined,
+      { plugins: [plugin] },
+    );
+
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error).toContain("required-plugin");
+      expect(result.error).toContain("message");
+    }
+  });
+});

--- a/packages/skaff-lib/tests/plugin-settings.test.ts
+++ b/packages/skaff-lib/tests/plugin-settings.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "@jest/globals";
+import z from "zod";
+
+import {
+  findMissingRequiredPluginSettings,
+  type LoadedTemplatePlugin,
+} from "../src/core/plugins";
+
+describe("plugin required settings", () => {
+  const plugin = {
+    reference: { module: "test-plugin" },
+    module: {
+      manifest: {
+        name: "test-plugin",
+        version: "0.0.0",
+        capabilities: ["template"],
+        supportedHooks: { template: [], cli: [], web: [] },
+        schemas: { input: true, output: true },
+        requiredSettingsKeys: ["message", "meta.level"],
+      },
+    },
+    name: "test-plugin",
+    version: "0.0.0",
+    requiredSettingsKeys: ["message", "meta.level"],
+    inputSchema: z.object({
+      message: z.string(),
+      meta: z.object({ level: z.string() }),
+    }),
+    outputSchema: z.object({
+      message: z.string(),
+      meta: z.object({ level: z.string() }),
+    }),
+  } satisfies LoadedTemplatePlugin;
+
+  it("returns missing required keys when plugin settings are incomplete", () => {
+    const missing = findMissingRequiredPluginSettings([plugin], {
+      name: "example",
+      plugins: {
+        "test-plugin": {
+          message: "hello",
+        },
+      },
+    });
+
+    expect(missing).toEqual([
+      { pluginName: "test-plugin", keys: ["meta.level"] },
+    ]);
+  });
+
+  it("returns empty when required keys are provided", () => {
+    const missing = findMissingRequiredPluginSettings([plugin], {
+      name: "example",
+      plugins: {
+        "test-plugin": {
+          message: "hello",
+          meta: { level: "info" },
+        },
+      },
+    });
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/skaff-lib/tests/template-config-typecheck.test.ts
+++ b/packages/skaff-lib/tests/template-config-typecheck.test.ts
@@ -58,6 +58,7 @@ export default {
 }
 
 describe("template config typechecking", () => {
+  jest.setTimeout(30000);
   it("resolves allowed dependencies from the host installation", async () => {
     const { rootDir, cleanup } = await createTemplateRoot();
     const previousCachePath = process.env.SKAFF_CACHE_PATH;

--- a/packages/skaff-lib/tests/template-plugin-integration.test.ts
+++ b/packages/skaff-lib/tests/template-plugin-integration.test.ts
@@ -17,8 +17,10 @@ import { PipelineBuilder, PipelineRunner } from "../src/core/generation/pipeline
 import type { TemplateInstantiationPipelineContext } from "../src/core/generation/pipeline/pipeline-stages";
 import { createLocalTestTemplateRepository } from "./helpers/template-fixtures";
 import greeterPluginModule from "../../../examples/plugins/plugin-greeter/src/index";
+import greeterCliPluginModule from "../../../examples/plugins/plugin-greeter-cli/src/index";
+import greeterWebPluginModule from "../../../examples/plugins/plugin-greeter-web/src/index";
 
-jest.setTimeout(15000);
+jest.setTimeout(30000);
 
 describe("template generation with local plugins", () => {
   afterEach(() => {
@@ -46,6 +48,22 @@ describe("template generation with local plugins", () => {
           "../../../examples/plugins/plugin-greeter/src/index.ts",
         ),
         packageName: "@timonteutelink/skaff-plugin-greeter",
+      },
+      {
+        moduleExports: greeterCliPluginModule,
+        modulePath: path.resolve(
+          __dirname,
+          "../../../examples/plugins/plugin-greeter-cli/src/index.ts",
+        ),
+        packageName: "@timonteutelink/skaff-plugin-greeter-cli",
+      },
+      {
+        moduleExports: greeterWebPluginModule,
+        modulePath: path.resolve(
+          __dirname,
+          "../../../examples/plugins/plugin-greeter-web/src/index.tsx",
+        ),
+        packageName: "@timonteutelink/skaff-plugin-greeter-web",
       },
     ]);
 


### PR DESCRIPTION
### Motivation
- Ensure `requiredSettingsKeys` declared by plugins are actually enforced during settings validation so templates cannot be instantiated with missing plugin input. 
- Run all plugin stage placements (`init`, `before-settings`, `after-settings`, `finalize`) so plugin-provided init and finalize flows are honored in both CLI and Web instantiation. 
- Merge plugin stage state into the resulting `plugins` settings so init/before/after/finalize stages can contribute values that are validated and used during generation. 
- Add tests and example updates to cover the new behavior and avoid regressions.

### Description
- Added `packages/skaff-lib/src/core/plugins/plugin-settings.ts` with `findMissingRequiredPluginSettings`, `validateRequiredPluginSettings`, and helpers for nested key lookup and formatting. 
- Enforced required plugin settings in core validation by calling `validateRequiredPluginSettings` from `Project.getFinalTemplateSettings` and when reading settings via CLI `readUserTemplateSettings`. 
- Extended CLI and Web instantiation flows to run `init` and `finalize` placements and to merge plugin stage state into the submitted `plugins` object, implemented in `apps/cli/src/utils/template-utils.ts` and `apps/web/src/app/projects/instantiate-template/page.tsx`, and added `loadWebTemplatePluginRequirements` to the web loader. 
- Updated greeter example plugins to include `init`/`finalize` stages and to declare `requiredSettingsKeys`, added a small React stub and JSX-runtime handling for sandboxed web-plugin evaluation, and added tests `plugin-settings.test.ts` and `plugin-required-settings-integration.test.ts` to cover validation and integration behavior.

### Testing
- Ran the full unit test suite with `cd packages/skaff-lib && bun run test` and observed all automated tests passing (Test Suites: 1 skipped, 23 passed; Tests: 4 skipped, 170 passed). 
- The test run emitted non-blocking warnings from TypeScript/Esbuild about missing base tsconfig files, but the suite completed successfully. 
- Example greeter plugin integration tests were added and executed as part of the test run and passed. 
- Manual Web dev start (`apps/web` Next) was not executed in CI because `next` is not available in the test harness, so UI runtime was not validated manually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ff6a8a870832586d26e197b79db42)