### PR TITLE
Add example plugin TypeScript configs

### DIFF
--- a/examples/plugins/typescript-config/base.json
+++ b/examples/plugins/typescript-config/base.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "incremental": false,
+    "isolatedModules": true,
+    "lib": ["es2022", "DOM", "DOM.Iterable"],
+    "module": "NodeNext",
+    "moduleDetection": "force",
+    "moduleResolution": "NodeNext",
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022"
+  }
+}

--- a/examples/plugins/typescript-config/react-library.json
+++ b/examples/plugins/typescript-config/react-library.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
### Motivation
- Fix a warning caused by example plugin tsconfigs extending `../typescript-config/...` when those files were missing.
- Provide resolvable shared TypeScript config files for example plugins so `extends` paths work without errors.

### Description
- Add `examples/plugins/typescript-config/base.json` containing shared `compilerOptions` used by plugins.
- Add `examples/plugins/typescript-config/react-library.json` which `extends` `./base.json` and sets `jsx: react-jsx`.
- These files were added to satisfy the `../typescript-config/...` `extends` references used by example plugin tsconfigs.

### Testing
- Ran `cd /workspace/skaff/packages/skaff-lib && bun run test` to execute the test suite.
- Test run succeeded: `1` test suite skipped, `23` test suites passed, and overall `170` tests passed with `4` skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69500f3ae03483259d07c624311677c2)