### PR TITLE
tests: introduce shared integration fixtures and refactor plugin tests

### DIFF
--- a/packages/skaff-lib/tests/actions-wiring.test.ts
+++ b/packages/skaff-lib/tests/actions-wiring.test.ts
@@ -63,7 +63,7 @@ jest.mock("../src/lib/logger", () => ({
   },
 }));
 
-describe("instantiate actions", () => {
+describe("actions wiring", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     for (const key of Object.keys(mockPlanner) as Array<

--- a/packages/skaff-lib/tests/helpers/integration-fixtures.ts
+++ b/packages/skaff-lib/tests/helpers/integration-fixtures.ts
@@ -1,0 +1,165 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { registerPluginModules } from "../../src/core/plugins";
+import greeterPluginModule from "../../../../examples/plugins/plugin-greeter/src/index";
+import greeterCliPluginModule from "../../../../examples/plugins/plugin-greeter-cli/src/index";
+import greeterWebPluginModule from "../../../../examples/plugins/plugin-greeter-web/src/index";
+
+export const testTemplatesRoot = path.resolve(
+  __dirname,
+  "../../../../templates/test-templates",
+);
+
+export const baseUserSettings = {
+  test_boolean: true,
+  test_string: "Whats 9 + 10?",
+  test_number: 21,
+  test_object: {
+    test_array: [
+      { test_string_in_array: "banananananana" },
+      { test_string_in_array: "banana" },
+    ],
+    more_stuff: "option2",
+  },
+  plugins: {
+    greeter: {
+      message: "Hello from the test suite!",
+    },
+  },
+};
+
+function toSafeName(name: string): string {
+  return name.replace(/[^a-z0-9]+/gi, "-").toLowerCase();
+}
+
+export async function createDeterministicTempDir(
+  name: string,
+  baseDir = "skaff-lib-integration",
+): Promise<string> {
+  const dir = path.join(os.tmpdir(), baseDir, toSafeName(name));
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+function restoreEnvironment(previousEnv: Record<string, string | undefined>): void {
+  if (previousEnv.SKAFF_CONFIG_PATH === undefined) {
+    delete process.env.SKAFF_CONFIG_PATH;
+  } else {
+    process.env.SKAFF_CONFIG_PATH = previousEnv.SKAFF_CONFIG_PATH;
+  }
+
+  if (previousEnv.TEMPLATE_DIR_PATHS === undefined) {
+    delete process.env.TEMPLATE_DIR_PATHS;
+  } else {
+    process.env.TEMPLATE_DIR_PATHS = previousEnv.TEMPLATE_DIR_PATHS;
+  }
+
+  if (previousEnv.SKAFF_CACHE_PATH === undefined) {
+    delete process.env.SKAFF_CACHE_PATH;
+  } else {
+    process.env.SKAFF_CACHE_PATH = previousEnv.SKAFF_CACHE_PATH;
+  }
+
+  if (previousEnv.SKAFF_DEV_TEMPLATES === undefined) {
+    delete process.env.SKAFF_DEV_TEMPLATES;
+  } else {
+    process.env.SKAFF_DEV_TEMPLATES = previousEnv.SKAFF_DEV_TEMPLATES;
+  }
+}
+
+export interface IntegrationTestEnvironment {
+  tempRoot: string;
+  projectParentDir: string;
+  cleanup: () => Promise<void>;
+}
+
+export async function setupIntegrationTestEnvironment(
+  testName: string,
+): Promise<IntegrationTestEnvironment> {
+  const tempRoot = await createDeterministicTempDir(testName);
+  const projectParentDir = path.join(tempRoot, "projects");
+  const configDir = path.join(tempRoot, "config");
+  const cacheDir = path.join(tempRoot, "cache");
+
+  await fs.mkdir(projectParentDir, { recursive: true });
+  await fs.mkdir(configDir, { recursive: true });
+  await fs.mkdir(cacheDir, { recursive: true });
+
+  const previousEnv = {
+    SKAFF_CONFIG_PATH: process.env.SKAFF_CONFIG_PATH,
+    TEMPLATE_DIR_PATHS: process.env.TEMPLATE_DIR_PATHS,
+    SKAFF_CACHE_PATH: process.env.SKAFF_CACHE_PATH,
+    SKAFF_DEV_TEMPLATES: process.env.SKAFF_DEV_TEMPLATES,
+  };
+
+  process.env.SKAFF_CONFIG_PATH = configDir;
+  process.env.TEMPLATE_DIR_PATHS = testTemplatesRoot;
+  process.env.SKAFF_CACHE_PATH = cacheDir;
+  process.env.SKAFF_DEV_TEMPLATES = "1";
+
+  return {
+    tempRoot,
+    projectParentDir,
+    cleanup: async () => {
+      restoreEnvironment(previousEnv);
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    },
+  };
+}
+
+export function registerGreeterPlugins(options?: {
+  includeSandboxedExports?: boolean;
+}): void {
+  const greeterCliModule = {
+    ...greeterCliPluginModule,
+    manifest: {
+      ...greeterCliPluginModule.manifest,
+      name: "greeter-cli",
+    },
+  };
+  const greeterWebModule = {
+    ...greeterWebPluginModule,
+    manifest: {
+      ...greeterWebPluginModule.manifest,
+      name: "greeter-web",
+    },
+  };
+
+  const includeSandboxedExports = options?.includeSandboxedExports ?? false;
+  const withSandboxedExports = <T extends { moduleExports: unknown }>(
+    entry: T,
+  ) =>
+    includeSandboxedExports
+      ? { ...entry, sandboxedExports: entry.moduleExports }
+      : entry;
+
+  registerPluginModules([
+    withSandboxedExports({
+      moduleExports: greeterPluginModule,
+      modulePath: path.resolve(
+        __dirname,
+        "../../../../examples/plugins/plugin-greeter/src/index.ts",
+      ),
+      packageName: "@timonteutelink/skaff-plugin-greeter",
+    }),
+    withSandboxedExports({
+      moduleExports: greeterCliModule,
+      modulePath: path.resolve(
+        __dirname,
+        "../../../../examples/plugins/plugin-greeter-cli/src/index.ts",
+      ),
+      packageName: "@timonteutelink/skaff-plugin-greeter-cli",
+    }),
+    withSandboxedExports({
+      moduleExports: greeterWebModule,
+      modulePath: path.resolve(
+        __dirname,
+        "../../../../examples/plugins/plugin-greeter-web/src/index.tsx",
+      ),
+      packageName: "@timonteutelink/skaff-plugin-greeter-web",
+    }),
+  ]);
+}

--- a/packages/skaff-lib/tests/template-plugin-integration.test.ts
+++ b/packages/skaff-lib/tests/template-plugin-integration.test.ts
@@ -1,10 +1,8 @@
 import { afterEach, describe, expect, it, jest } from "@jest/globals";
-import path from "node:path";
 
 import {
   clearRegisteredPluginModules,
   loadPluginsForTemplate,
-  registerPluginModules,
 } from "../src/core/plugins";
 import {
   createDefaultContainer,
@@ -16,9 +14,7 @@ import { createTemplateView } from "../src/core/plugins/template-view";
 import { PipelineBuilder, PipelineRunner } from "../src/core/generation/pipeline/pipeline-runner";
 import type { TemplateInstantiationPipelineContext } from "../src/core/generation/pipeline/pipeline-stages";
 import { createLocalTestTemplateRepository } from "./helpers/template-fixtures";
-import greeterPluginModule from "../../../examples/plugins/plugin-greeter/src/index";
-import greeterCliPluginModule from "../../../examples/plugins/plugin-greeter-cli/src/index";
-import greeterWebPluginModule from "../../../examples/plugins/plugin-greeter-web/src/index";
+import { registerGreeterPlugins } from "./helpers/integration-fixtures";
 
 jest.setTimeout(30000);
 
@@ -40,32 +36,7 @@ describe("template generation with local plugins", () => {
       },
     ];
 
-    registerPluginModules([
-      {
-        moduleExports: greeterPluginModule,
-        modulePath: path.resolve(
-          __dirname,
-          "../../../examples/plugins/plugin-greeter/src/index.ts",
-        ),
-        packageName: "@timonteutelink/skaff-plugin-greeter",
-      },
-      {
-        moduleExports: greeterCliPluginModule,
-        modulePath: path.resolve(
-          __dirname,
-          "../../../examples/plugins/plugin-greeter-cli/src/index.ts",
-        ),
-        packageName: "@timonteutelink/skaff-plugin-greeter-cli",
-      },
-      {
-        moduleExports: greeterWebPluginModule,
-        modulePath: path.resolve(
-          __dirname,
-          "../../../examples/plugins/plugin-greeter-web/src/index.tsx",
-        ),
-        packageName: "@timonteutelink/skaff-plugin-greeter-web",
-      },
-    ]);
+    registerGreeterPlugins();
 
     try {
       const pluginsResult = await loadPluginsForTemplate(


### PR DESCRIPTION
### Motivation

- Reduce duplication across integration tests by extracting common environment and plugin setup into shared helpers.  
- Make integration tests more readable and maintainable while preserving existing semantics.  
- Consolidate repeated DI/wiring unit tests into a single, focused wiring test file to avoid repetition.  

### Description

- Add `packages/skaff-lib/tests/helpers/integration-fixtures.ts` providing `createDeterministicTempDir`, `setupIntegrationTestEnvironment`, `registerGreeterPlugins`, `baseUserSettings`, and `testTemplatesRoot`.  
- Refactor `instantiate-actions.integration.test.ts` and `template-plugin-integration.test.ts` to consume the shared helpers and use the provided deterministic temp dir, env setup and greeter plugin registration.  
- Rename and consolidate the previous instantiate-actions wiring tests to `packages/skaff-lib/tests/actions-wiring.test.ts` and update the `describe` label to `actions wiring`.  
- Keep refactor minimal and behaviour-preserving (tests still register greeter plugins, use deterministic UUIDs and perform the same assertions).  

### Testing

- Built type package with `cd packages/template-types-lib && bun run build` which completed successfully.  
- Built the library with `cd packages/skaff-lib && bun run build` which completed successfully.  
- Ran the full test suite with `cd packages/skaff-lib && bun run test` and observed tests pass (`24` test suites total: `24` passed, `1` skipped; `175` tests passed, `4` skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69514e05df288325bf72785e02ca3f70)