### PR TITLE
Remove react/inquirer coupling from skaff-lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Skaff executes user‑provided template code (such as `templateConfig.ts` and pl
 | **No process/environment**  | `process`, `child_process` and environment variables are blocked.                                                                                                              |
 | **Frozen intrinsics**       | All built‑in prototypes (`Object`, `Array`, `Function`, etc.) are frozen after `lockdown()`, preventing prototype pollution.                                                   |
 | **Deterministic execution** | `Date.now()` and `Math.random()` are disabled by default for reproducible builds.                                                                                              |
-| **Whitelisted imports**     | Only explicitly allowed modules can be `require()`d: `yaml`, `zod`, `handlebars`, and `@timonteutelink/template-types-lib`. Plugins additionally receive a minimal React stub. |
+| **Whitelisted imports**     | Only explicitly allowed modules can be `require()`d: `yaml`, `zod`, `handlebars`, and `@timonteutelink/template-types-lib`. Plugins may receive extra environment-registered stubs (for example, the Web UI registers a minimal React stub via `registerPluginSandboxLibraries`). |
 
 ### Where sandboxing is applied
 

--- a/apps/cli/src/utils/plugin-types.ts
+++ b/apps/cli/src/utils/plugin-types.ts
@@ -1,0 +1,12 @@
+import type * as prompts from "@inquirer/prompts";
+import type {
+  CliPluginContribution as BaseCliPluginContribution,
+  CliTemplateStage as BaseCliTemplateStage,
+} from "@timonteutelink/skaff-lib";
+
+export type CliTemplateStage<TState = unknown> = BaseCliTemplateStage<
+  TState,
+  typeof prompts
+>;
+
+export type CliPluginContribution = BaseCliPluginContribution<typeof prompts>;

--- a/apps/cli/src/utils/template-utils.ts
+++ b/apps/cli/src/utils/template-utils.ts
@@ -5,7 +5,8 @@ import fs from 'node:fs'
 import * as prompts from '@inquirer/prompts'
 
 import {promptForSchema} from './zod-schema-prompt.js'
-import type {CliTemplateStage, PluginStageEntry} from '@timonteutelink/skaff-lib'
+import type {PluginStageEntry} from '@timonteutelink/skaff-lib'
+import type {CliTemplateStage} from './plugin-types.js'
 
 type StageEntry = PluginStageEntry<CliTemplateStage>
 

--- a/apps/web/src/lib/plugins/plugin-types.ts
+++ b/apps/web/src/lib/plugins/plugin-types.ts
@@ -1,0 +1,17 @@
+import type React from "react";
+import type {
+  WebPluginContribution as BaseWebPluginContribution,
+  WebTemplateStage as BaseWebTemplateStage,
+} from "@timonteutelink/skaff-lib";
+
+export type WebTemplateStage<TState = unknown> = BaseWebTemplateStage<
+  TState,
+  React.ReactNode
+>;
+
+export type WebPluginContribution = Omit<
+  BaseWebPluginContribution,
+  "templateStages"
+> & {
+  templateStages?: WebTemplateStage[];
+};

--- a/apps/web/src/lib/plugins/react-sandbox-stub.ts
+++ b/apps/web/src/lib/plugins/react-sandbox-stub.ts
@@ -1,0 +1,53 @@
+/**
+ * React stub for plugin sandboxing in the web environment.
+ *
+ * Plugins that ship UI stages can import React when they are evaluated in the
+ * sandbox. This stub keeps the code loading while preventing any real DOM or
+ * browser access.
+ */
+export const REACT_SANDBOX_STUB = Object.freeze({
+  // Return null (frozen primitive) instead of creating elements
+  createElement: Object.freeze(() => null),
+
+  // Use a frozen symbol
+  Fragment: Object.freeze(Symbol.for("react.fragment")),
+
+  // Return frozen tuple with no-op setter
+  useState: Object.freeze(() => Object.freeze([null, Object.freeze(() => {})])),
+
+  // No-op effect
+  useEffect: Object.freeze(() => {}),
+
+  // Return the callback as-is (it's already from sandboxed code)
+  useCallback: Object.freeze((fn: unknown) => fn),
+
+  // Execute and return result (no memoization in stub)
+  useMemo: Object.freeze((fn: () => unknown) =>
+    typeof fn === "function" ? fn() : null,
+  ),
+
+  // Return frozen ref object
+  useRef: Object.freeze(() => Object.freeze({ current: null })),
+
+  // Additional commonly used hooks as no-ops
+  useContext: Object.freeze(() => null),
+  useReducer: Object.freeze(() =>
+    Object.freeze([null, Object.freeze(() => {})]),
+  ),
+  useLayoutEffect: Object.freeze(() => {}),
+  useImperativeHandle: Object.freeze(() => {}),
+  useDebugValue: Object.freeze(() => {}),
+  useDeferredValue: Object.freeze((value: unknown) => value),
+  useTransition: Object.freeze(() =>
+    Object.freeze([false, Object.freeze(() => {})]),
+  ),
+  useId: Object.freeze(() => "sandbox-id"),
+  useSyncExternalStore: Object.freeze(() => null),
+  useInsertionEffect: Object.freeze(() => {}),
+});
+
+export const REACT_JSX_RUNTIME_SANDBOX_STUB = Object.freeze({
+  Fragment: "sandbox-fragment",
+  jsx: Object.freeze(() => null),
+  jsxs: Object.freeze(() => null),
+});

--- a/apps/web/src/lib/plugins/register-plugins.ts
+++ b/apps/web/src/lib/plugins/register-plugins.ts
@@ -1,11 +1,22 @@
-import { registerPluginModules } from "@timonteutelink/skaff-lib";
+import {
+  registerPluginModules,
+  registerPluginSandboxLibraries,
+} from "@timonteutelink/skaff-lib";
 
 import { INSTALLED_PLUGINS } from "./generated-plugin-registry";
+import {
+  REACT_JSX_RUNTIME_SANDBOX_STUB,
+  REACT_SANDBOX_STUB,
+} from "./react-sandbox-stub";
 
 let registered = false;
 
 export function ensureWebPluginsRegistered(): void {
   if (registered) return;
+  registerPluginSandboxLibraries({
+    react: REACT_SANDBOX_STUB,
+    "react/jsx-runtime": REACT_JSX_RUNTIME_SANDBOX_STUB,
+  });
   const entries = Object.values(INSTALLED_PLUGINS).map((entry) => ({
     moduleExports: entry.module,
     modulePath: entry.modulePath,

--- a/apps/web/src/lib/plugins/web-stage-loader.ts
+++ b/apps/web/src/lib/plugins/web-stage-loader.ts
@@ -11,12 +11,11 @@
 
 import type {
   SkaffPluginModule,
-  WebPluginContribution,
-  WebTemplateStage,
   PluginStageEntry,
   TemplatePluginConfig,
   PluginTrustLevel,
 } from "@timonteutelink/skaff-lib";
+import type { WebPluginContribution, WebTemplateStage } from "./plugin-types";
 
 import {
   normalizeTemplatePlugins,

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "skaff",
@@ -173,11 +172,9 @@
         "zod": "^4.1.12",
       },
       "devDependencies": {
-        "@inquirer/prompts": "^8.0.1",
         "@swc/jest": "^0.2.39",
         "@types/bun": "^1.3.2",
         "@types/fs-extra": "^11.0.4",
-        "@types/react": "^19.0.0",
         "@types/semver": "^7.7.1",
         "eslint": "^9.39.1",
         "eslint-config-prettier": "^10.1.8",

--- a/examples/plugins/plugin-greeter-cli/src/index.ts
+++ b/examples/plugins/plugin-greeter-cli/src/index.ts
@@ -6,6 +6,7 @@ import type {
 import { GREETER_PLUGIN_NAME } from "../../plugin-greeter-types/src/index";
 
 type GreeterStageState = { disabled?: boolean; message?: string };
+type InquirerPrompts = typeof import("@inquirer/prompts");
 
 const greeterCliCommand: PluginCliCommand = {
   name: "greet",
@@ -25,7 +26,10 @@ const greeterCliCommand: PluginCliCommand = {
   },
 };
 
-const greeterCliBeforeStage: CliTemplateStage<GreeterStageState> = {
+const greeterCliBeforeStage: CliTemplateStage<
+  GreeterStageState,
+  InquirerPrompts
+> = {
   id: "greeter-cli-before",
   placement: "before-settings",
   async run({ prompts, setStageState }) {
@@ -39,7 +43,10 @@ const greeterCliBeforeStage: CliTemplateStage<GreeterStageState> = {
   },
 };
 
-const greeterCliInitStage: CliTemplateStage<GreeterStageState> = {
+const greeterCliInitStage: CliTemplateStage<
+  GreeterStageState,
+  InquirerPrompts
+> = {
   id: "greeter-cli-init",
   placement: "init",
   async run({ prompts, setStageState }) {
@@ -79,7 +86,7 @@ const greeterCliFinalizeStage: CliTemplateStage<GreeterStageState> = {
   },
 };
 
-const greeterCliContribution: CliPluginContribution = {
+const greeterCliContribution: CliPluginContribution<InquirerPrompts> = {
   commands: [greeterCliCommand],
   templateStages: [
     greeterCliInitStage,

--- a/packages/skaff-lib/jest.config.ts
+++ b/packages/skaff-lib/jest.config.ts
@@ -23,7 +23,6 @@ const config: Config = {
   setupFiles: ["<rootDir>/tests/setup-env.ts"],
   moduleNameMapper: {
     "^ses$": "<rootDir>/tests/mocks/ses.ts",
-    "^react$": "<rootDir>/tests/mocks/react.ts",
     "^@timonteutelink/template-types-lib$":
       "<rootDir>/../template-types-lib/dist/index.js",
     "^@timonteutelink/skaff-plugin-greeter-types$":

--- a/packages/skaff-lib/package.json
+++ b/packages/skaff-lib/package.json
@@ -27,11 +27,9 @@
     "test:watch": "jest --watch"
   },
   "devDependencies": {
-    "@inquirer/prompts": "^8.0.1",
     "@swc/jest": "^0.2.39",
     "@types/bun": "^1.3.2",
     "@types/fs-extra": "^11.0.4",
-    "@types/react": "^19.0.0",
     "@types/semver": "^7.7.1",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",

--- a/packages/skaff-lib/src/core/plugins/plugin-types.ts
+++ b/packages/skaff-lib/src/core/plugins/plugin-types.ts
@@ -12,7 +12,6 @@ import type {
   TemplatePluginEntrypoint,
 } from "../generation/template-generation-types";
 import { z } from "zod";
-import type React from "react";
 
 /**
  * Re-export ReadonlyProjectContext for plugin authors.
@@ -552,14 +551,16 @@ export function findPluginCommand(
   );
 }
 
-export interface CliPluginContribution {
+export interface CliPluginContribution<TPrompts = CliPromptModule> {
   commands?: PluginCliCommand[];
-  templateStages?: CliTemplateStage[];
+  templateStages?: CliTemplateStage<any, TPrompts>[];
 }
 
-export type CliPluginEntrypoint =
-  | CliPluginContribution
-  | (() => CliPluginContribution | Promise<CliPluginContribution>);
+export type CliPluginEntrypoint<TPrompts = CliPromptModule> =
+  | CliPluginContribution<TPrompts>
+  | (() =>
+      | CliPluginContribution<TPrompts>
+      | Promise<CliPluginContribution<TPrompts>>);
 
 /**
  * Context provided to web plugin getNotices function.
@@ -660,7 +661,7 @@ export interface WebTemplateStageRenderProps<
  * Stage state is automatically namespaced using the plugin name,
  * preventing collisions between plugins.
  */
-export interface WebTemplateStage<TState = unknown> {
+export interface WebTemplateStage<TState = unknown, TRender = unknown> {
   /** Unique identifier for this stage within the plugin */
   id: string;
   /** When this stage should run in the template instantiation flow */
@@ -675,7 +676,7 @@ export interface WebTemplateStage<TState = unknown> {
     context: WebTemplateStageContext<TState>,
   ) => boolean | Promise<boolean>;
   /** Render the stage UI */
-  render: (props: WebTemplateStageRenderProps<TState>) => React.ReactNode;
+  render: (props: WebTemplateStageRenderProps<TState>) => TRender;
 }
 
 export interface CliTemplateStageContext<
@@ -696,7 +697,12 @@ export interface CliTemplateStageContext<
  * Stage state is automatically namespaced using the plugin name,
  * preventing collisions between plugins.
  */
-export interface CliTemplateStage<TState = unknown> {
+export type CliPromptModule = object;
+
+export interface CliTemplateStage<
+  TState = unknown,
+  TPrompts = CliPromptModule,
+> {
   /** Unique identifier for this stage within the plugin */
   id: string;
   /** When this stage should run in the template instantiation flow */
@@ -713,7 +719,7 @@ export interface CliTemplateStage<TState = unknown> {
   /** Execute the stage logic */
   run: (
     context: CliTemplateStageContext<TState> & {
-      prompts: typeof import("@inquirer/prompts");
+      prompts: TPrompts;
     },
   ) => Promise<UserTemplateSettings | void | undefined>;
 }

--- a/packages/skaff-lib/src/index.ts
+++ b/packages/skaff-lib/src/index.ts
@@ -61,6 +61,7 @@ export {
 export {
   getSandboxLibraries,
   getPluginSandboxLibraries,
+  registerPluginSandboxLibraries,
 } from "./core/infra/sandbox-endowments";
 export {
   createDefaultContainer,

--- a/packages/skaff-lib/tests/mocks/react.ts
+++ b/packages/skaff-lib/tests/mocks/react.ts
@@ -1,8 +1,0 @@
-export const useState = <T,>(initial: T): [T, (next: T) => void] => [
-  initial,
-  () => {},
-];
-
-const React = { useState };
-
-export default React;


### PR DESCRIPTION
### Motivation

- Decouple `skaff-lib` from UI and interactive prompt libraries so the core library can be environment-agnostic and have zero runtime dependency on `react` or `inquirer`.
- Make plugin surface types generic so the CLI and Web apps can provide concrete prompt and render types in their own packages.
- Avoid shipping UI stubs and inquirer typings from the library to reduce runtime weight and cross-package coupling.
- Provide a mechanism for environment-specific sandbox endowments to be registered by the CLI/Web rather than baked into the library.

### Description

- Removed `react`/`inquirer` test/dev coupling from `packages/skaff-lib` by deleting the React test mock and removing `@inquirer/prompts` and `@types/react` entries from `packages/skaff-lib/package.json` and `jest.config.ts` mappings.
- Made plugin type signatures generic: `WebTemplateStage.render` now returns a generic `TRender` and `CliTemplateStage.run` accepts a generic prompts type, and `CliPluginContribution`/`CliPluginEntrypoint` are now parameterized by prompt types.
- Replaced the built-in React sandbox stub with a `registerPluginSandboxLibraries` API in `packages/skaff-lib/src/core/infra/sandbox-endowments.ts` and exported it from the library, allowing environments to inject their own stubs.
- Implemented environment-side pieces: added `apps/web/src/lib/plugins/react-sandbox-stub.ts` and have the web app call `registerPluginSandboxLibraries` to register React stubs, and added `apps/cli/src/utils/plugin-types.ts` and `apps/web/src/lib/plugins/plugin-types.ts` to provide concrete type aliases for CLI and Web respectively, plus small updates to example plugin types and README sandbox docs.

### Testing

- Ran `bun install` at repo root and dependencies were installed successfully (lockfile updated). 
- Ran `cd packages/skaff-lib && bun run test`, which runs `tsc` then `jest`, and the build/test step failed during TypeScript compilation.
- Failure details: `tsc` reported missing/renamed exports from `@timonteutelink/template-types-lib` (several `TS2305` / `TS2724` errors) preventing the `skaff-lib` build. 
- No Jest unit tests were executed successfully due to the TypeScript build errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695193879d848325be5bb5e4b16957df)