### PR TITLE
Add nested subtemplate/update integration tests and wire skaff-lib test/build scripts

### DIFF
--- a/.github/workflows/testLib.yml
+++ b/.github/workflows/testLib.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           bun-version: 1.2.21
       - name: Install dependencies
-        run: cd packages/skaff-lib && bun install --frozen-lockfile --ignore-scripts
+        run: bun install --frozen-lockfile --ignore-scripts
       # - name: Lint
       #   run: cd packages/skaff-lib && bun run lint
       - name: Test
-        run: cd packages/skaff-lib && bun run test
+        run: bun run test:skaff-lib

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@
 - Documentation under `packages/docs` is outdated; touch it only if you intend to modernize it and ensure it stays consistent with the `README.md`.
 - Before submitting any change, run the full test suite: `cd packages/skaff-lib && bun run test`. Do not skip tests.
 - If your work affects behavior that lacks coverage, add or extend tests accordingly.
+- Skaff-lib and template-types-lib are referenced via their built JavaScript outputs. Always build both before running tests. Use `bun run test:skaff-lib` from the repo root (or `bun run test:ci` inside `packages/skaff-lib`) to run the builds + tests together.
+- If dependency state gets inconsistent, optionally run `make cr` before `bun install`, builds, and tests.
 
 ## General expectations
 - Ensure any documentation edits remain consistent across the repo.

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ We appreciate contributions of all kinds. Please see [CONTRIBUTING.md](./CONTRIB
 
 - Set up the monorepo with `bun install` and build the core libs
 - Use `bun test` to run unit tests, and run `bun format` / `bun lint` before committing
+- Skaff-lib tests require built JavaScript outputs for `template-types-lib` and `skaff-lib`. Use `bun run test:skaff-lib` from the repo root (or `bun run test:ci` in `packages/skaff-lib`) to build both before running Jest.
 - Work on a feature branch and open a Pull Request against `main`. PRs run continuous integration and should be kept focused
 - Releases are handled by maintainers via semantic versioning and GitHub Actions; you usually don’t need to publish packages yourself
 

--- a/examples/test-templates/test-template-repo/templates/test-template/test-subtemplate-add/test-add/files/added.txt
+++ b/examples/test-templates/test-template-repo/templates/test-template/test-subtemplate-add/test-add/files/added.txt
@@ -1,0 +1,1 @@
+Added note: {{note}}

--- a/examples/test-templates/test-template-repo/templates/test-template/test-subtemplate-add/test-add/templateConfig.ts
+++ b/examples/test-templates/test-template-repo/templates/test-template/test-subtemplate-add/test-add/templateConfig.ts
@@ -1,0 +1,49 @@
+import z from "zod";
+import {
+  TemplateConfig,
+  TemplateConfigModule,
+} from "@timonteutelink/template-types-lib";
+
+const templateSettingsSchema = z.object({
+  note: z
+    .string()
+    .default("Added note")
+    .describe("A note for the added subtemplate"),
+});
+
+const templateFinalSettingsSchema = templateSettingsSchema;
+
+const templateConfig: TemplateConfig = {
+  name: "test_add",
+  description: "An added subtemplate with nested auto-instantiation",
+  author: "Timon Teutelink",
+  specVersion: "1.0.0",
+};
+
+const templateConfigModule: TemplateConfigModule<{}, typeof templateSettingsSchema> = {
+  templateConfig,
+  targetPath: "./added",
+  templateSettingsSchema,
+  templateFinalSettingsSchema,
+  mapFinalSettings: ({ templateSettings }) => ({
+    ...templateSettings,
+  }),
+  autoInstantiatedSubtemplates: [
+    {
+      subTemplateName: "test_add_nested",
+      mapSettings: (finalSettings) => ({
+        detail: `Nested: ${finalSettings.note}`,
+      }),
+      children: [
+        {
+          subTemplateName: "test_add_grandchild",
+          mapSettings: (finalSettings) => ({
+            info: `Grandchild: ${(finalSettings as { detail?: string }).detail ?? ""}`,
+          }),
+        },
+      ],
+    },
+  ],
+};
+
+export default templateConfigModule;

--- a/examples/test-templates/test-template-repo/templates/test-template/test-subtemplate-add/test-add/test-add-nested/files/nested.txt
+++ b/examples/test-templates/test-template-repo/templates/test-template/test-subtemplate-add/test-add/test-add-nested/files/nested.txt
@@ -1,0 +1,1 @@
+Nested note: {{detail}}

--- a/examples/test-templates/test-template-repo/templates/test-template/test-subtemplate-add/test-add/test-add-nested/templateConfig.ts
+++ b/examples/test-templates/test-template-repo/templates/test-template/test-subtemplate-add/test-add/test-add-nested/templateConfig.ts
@@ -1,0 +1,33 @@
+import z from "zod";
+import {
+  TemplateConfig,
+  TemplateConfigModule,
+} from "@timonteutelink/template-types-lib";
+
+const templateSettingsSchema = z.object({
+  detail: z
+    .string()
+    .default("Nested detail")
+    .describe("A detail for the nested subtemplate"),
+});
+
+const templateFinalSettingsSchema = templateSettingsSchema;
+
+const templateConfig: TemplateConfig = {
+  name: "test_add_nested",
+  description: "Nested subtemplate for add tests",
+  author: "Timon Teutelink",
+  specVersion: "1.0.0",
+};
+
+const templateConfigModule: TemplateConfigModule<{}, typeof templateSettingsSchema> = {
+  templateConfig,
+  targetPath: "./added/nested",
+  templateSettingsSchema,
+  templateFinalSettingsSchema,
+  mapFinalSettings: ({ templateSettings }) => ({
+    ...templateSettings,
+  }),
+};
+
+export default templateConfigModule;

--- a/examples/test-templates/test-template-repo/templates/test-template/test-subtemplate-add/test-add/test-add-nested/test-add-grandchild/files/grandchild.txt
+++ b/examples/test-templates/test-template-repo/templates/test-template/test-subtemplate-add/test-add/test-add-nested/test-add-grandchild/files/grandchild.txt
@@ -1,0 +1,1 @@
+Grandchild note: {{info}}

--- a/examples/test-templates/test-template-repo/templates/test-template/test-subtemplate-add/test-add/test-add-nested/test-add-grandchild/templateConfig.ts
+++ b/examples/test-templates/test-template-repo/templates/test-template/test-subtemplate-add/test-add/test-add-nested/test-add-grandchild/templateConfig.ts
@@ -1,0 +1,33 @@
+import z from "zod";
+import {
+  TemplateConfig,
+  TemplateConfigModule,
+} from "@timonteutelink/template-types-lib";
+
+const templateSettingsSchema = z.object({
+  info: z
+    .string()
+    .default("Grandchild info")
+    .describe("A note for the grandchild subtemplate"),
+});
+
+const templateFinalSettingsSchema = templateSettingsSchema;
+
+const templateConfig: TemplateConfig = {
+  name: "test_add_grandchild",
+  description: "Grandchild subtemplate for add tests",
+  author: "Timon Teutelink",
+  specVersion: "1.0.0",
+};
+
+const templateConfigModule: TemplateConfigModule<{}, typeof templateSettingsSchema> = {
+  templateConfig,
+  targetPath: "./added/nested/grandchild",
+  templateSettingsSchema,
+  templateFinalSettingsSchema,
+  mapFinalSettings: ({ templateSettings }) => ({
+    ...templateSettings,
+  }),
+};
+
+export default templateConfigModule;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "buildNixWeb": "nix-web && bun i && git add -A && nix build .#skaff-web",
     "buildNixCli": "nix-cli && bun i && git add -A && nix build .#skaff-cli",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
-    "postinstall": "./scripts/bun2nix.sh || exit 0"
+    "postinstall": "./scripts/bun2nix.sh || exit 0",
+    "test:skaff-lib": "cd packages/skaff-lib && bun run test:ci"
   },
   "devDependencies": {
     "prettier": "^3.6.2",

--- a/packages/skaff-lib/package.json
+++ b/packages/skaff-lib/package.json
@@ -23,7 +23,8 @@
     "build": "rm -rf dist && tsc -p tsconfig.json",
     "lint": "eslint . --max-warnings 0",
     "check-types": "tsc --noEmit",
-    "test": "cd ../template-types-lib && bun run build && cd ../skaff-lib && bun run build && jest",
+    "test": "bun run test:ci",
+    "test:ci": "cd ../template-types-lib && bun run build && cd ../skaff-lib && bun run build && jest",
     "test:watch": "jest --watch"
   },
   "devDependencies": {

--- a/packages/skaff-lib/tests/template-update.integration.test.ts
+++ b/packages/skaff-lib/tests/template-update.integration.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import fs from "node:fs/promises";
+import path from "node:path";
+import simpleGit, { type SimpleGit } from "simple-git";
+
+import { generateNewProject } from "../src/actions/instantiate/generate-new-project";
+import { prepareUpdateDiff } from "../src/actions/instantiate/prepare-update-diff";
+import { resolveProjectDiffPlanner } from "../src/core/diffing/ProjectDiffPlanner";
+import { createDefaultContainer, resetSkaffContainer, setSkaffContainer } from "../src/di/container";
+import { NpmService } from "../src/core/infra/npm-service";
+import { Project } from "../src/models/project";
+import { setupIntegrationTestEnvironment } from "./helpers/integration-fixtures";
+
+jest.setTimeout(30000);
+
+const updateUserSettings = {
+  greeting: "Hello update",
+};
+
+const templateConfigContents = `import z from "zod";
+import { TemplateConfig, TemplateConfigModule } from "@timonteutelink/template-types-lib";
+
+const templateSettingsSchema = z.object({
+  greeting: z.string().default("Hello from update template"),
+});
+
+const templateFinalSettingsSchema = templateSettingsSchema;
+
+const templateConfig: TemplateConfig = {
+  name: "update_template",
+  description: "Template used to test updates",
+  author: "Skaff Test Suite",
+  specVersion: "1.0.0",
+  isRootTemplate: true,
+};
+
+const templateConfigModule: TemplateConfigModule<{}, typeof templateSettingsSchema> = {
+  templateConfig,
+  targetPath: ".",
+  templateSettingsSchema,
+  templateFinalSettingsSchema,
+  mapFinalSettings: ({ templateSettings }) => ({
+    ...templateSettings,
+  }),
+};
+
+export default templateConfigModule;
+`;
+
+async function writeTemplateVersion(
+  repoPath: string,
+  versionLabel: string,
+): Promise<void> {
+  const templateDir = path.join(repoPath, "templates", "update-template");
+  const filesDir = path.join(templateDir, "files");
+  await fs.mkdir(filesDir, { recursive: true });
+  await fs.writeFile(
+    path.join(templateDir, "templateConfig.ts"),
+    templateConfigContents,
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(filesDir, "README.md.hbs"),
+    `Version ${versionLabel}: {{greeting}}\n`,
+    "utf8",
+  );
+}
+
+async function createVersionedTemplateRepo(
+  repoPath: string,
+): Promise<{ git: SimpleGit; baseHash: string; updatedHash: string }> {
+  await fs.mkdir(repoPath, { recursive: true });
+  const git = simpleGit(repoPath);
+  await git.init();
+  await git.addConfig("user.email", "test@example.com");
+  await git.addConfig("user.name", "Skaff Test");
+
+  await writeTemplateVersion(repoPath, "1");
+  await git.add(".");
+  await git.commit("Initial template");
+  const baseHash = (await git.revparse(["HEAD"])).trim();
+
+  await writeTemplateVersion(repoPath, "2");
+  await git.add(".");
+  await git.commit("Update template");
+  const updatedHash = (await git.revparse(["HEAD"])).trim();
+
+  await git.checkout(baseHash);
+
+  return { git, baseHash, updatedHash };
+}
+
+let projectParentDir = "";
+let integrationEnvironment:
+  | Awaited<ReturnType<typeof setupIntegrationTestEnvironment>>
+  | undefined;
+let repoInfo:
+  | { repoPath: string; baseHash: string; updatedHash: string }
+  | undefined;
+let npmInstallSpy: jest.SpiedFunction<NpmService["install"]> | undefined;
+
+beforeEach(async () => {
+  const testName = expect.getState().currentTestName ?? "update-integration";
+  integrationEnvironment = await setupIntegrationTestEnvironment(testName, {
+    templateDirPaths: async (tempRoot) => {
+      const repoPath = path.join(tempRoot, "template-repo");
+      const { baseHash, updatedHash } = await createVersionedTemplateRepo(repoPath);
+      repoInfo = { repoPath, baseHash, updatedHash };
+      return [repoPath];
+    },
+  });
+  projectParentDir = integrationEnvironment.projectParentDir;
+
+  const container = createDefaultContainer();
+  setSkaffContainer(container);
+
+  npmInstallSpy = jest
+    .spyOn(NpmService.prototype, "install")
+    .mockResolvedValue({ data: undefined });
+});
+
+afterEach(async () => {
+  npmInstallSpy?.mockRestore();
+  resetSkaffContainer();
+  if (integrationEnvironment) {
+    await integrationEnvironment.cleanup();
+    integrationEnvironment = undefined;
+  }
+  repoInfo = undefined;
+});
+
+describe("template update integration", () => {
+  it("updates a project when the template revision changes", async () => {
+    if (!repoInfo) {
+      throw new Error("Template repo was not initialized.");
+    }
+
+    const creationResult = await generateNewProject(
+      "update-project",
+      "update_template",
+      projectParentDir,
+      updateUserSettings,
+      { git: true },
+    );
+
+    expect("error" in creationResult).toBe(false);
+
+    const projectDir = path.join(projectParentDir, "update-project");
+    const initialReadme = await fs.readFile(
+      path.join(projectDir, "README.md"),
+      "utf8",
+    );
+    expect(initialReadme.trim()).toBe("Version 1: Hello update");
+
+    const projectResult = await Project.create(projectDir);
+    if ("error" in projectResult) {
+      throw new Error(projectResult.error);
+    }
+
+    const diffResult = await prepareUpdateDiff(
+      projectResult.data,
+      repoInfo.updatedHash,
+    );
+
+    if ("error" in diffResult) {
+      throw new Error(diffResult.error);
+    }
+
+    expect(diffResult.data.parsedDiff.map((file) => file.path)).toEqual(
+      expect.arrayContaining(["README.md", "templateSettings.json"]),
+    );
+
+    const planner = resolveProjectDiffPlanner();
+    const applyResult = await planner.applyDiffToProject(
+      projectResult.data,
+      diffResult.data.diffHash,
+    );
+
+    if ("error" in applyResult) {
+      throw new Error(applyResult.error);
+    }
+
+    const updatedReadme = await fs.readFile(
+      path.join(projectDir, "README.md"),
+      "utf8",
+    );
+    expect(updatedReadme.trim()).toBe("Version 2: Hello update");
+
+    const settings = JSON.parse(
+      await fs.readFile(path.join(projectDir, "templateSettings.json"), "utf8"),
+    ) as {
+      instantiatedTemplates: Array<{
+        templateName: string;
+        templateCommitHash?: string;
+      }>;
+    };
+
+    const rootInstance = settings.instantiatedTemplates.find(
+      (template) => template.templateName === "update_template",
+    );
+    expect(rootInstance?.templateCommitHash).toBe(repoInfo.updatedHash);
+  });
+});


### PR DESCRIPTION
### Motivation
- Expand integration coverage to exercise adding subtemplates, nested auto-instantiation, and template update flows via generated diffs. 
- Ensure `skaff-lib` tests run against built JavaScript outputs of `template-types-lib` and `skaff-lib` so the integration tests exercise compiled code. 
- Make integration fixtures configurable so tests can inject temporary template repos and control dev-template behavior. 
- Fix a mismatch where the update test expected `README.md` but the template emitted `README.md.hbs` so update diffs could be applied and asserted.

### Description
- Add nested test-template fixtures and a new `template-update.integration.test.ts` that creates a git-backed template repo and verifies `prepareUpdateDiff` behavior. 
- Extend `instantiate-actions.integration.test.ts` with a test that exercises `prepareInstantiationDiff` and applies diffs to auto-instantiate nested subtemplates. 
- Make `setupIntegrationTestEnvironment` in `packages/skaff-lib/tests/helpers/integration-fixtures.ts` accept an `options` object to control `templateDirPaths` and `devTemplates`, and set `TEMPLATE_DIR_PATHS`/`SKAFF_DEV_TEMPLATES` accordingly. 
- Wire repo-level test scripts and CI: add `test:skaff-lib` to the root `package.json`, add `test:ci` in `packages/skaff-lib/package.json` to build `template-types-lib` and `skaff-lib` before running `jest`, and document the build/test requirement in `AGENTS.md` and `README.md`; also fix generation to emit `README.md` via `README.md.hbs` and update the integration test to read that file.

### Testing
- Ran the full repo integration flow with `make cr`, `bun install --frozen-lockfile --ignore-scripts`, and `bun run test:skaff-lib` from the repo root. 
- The automated Jest run executed the `packages/skaff-lib` test suite and all test suites passed. 
- Test summary: `31` test suites and `205` tests ran and passed with the new integration coverage. 
- The failing `template-update` assertion (missing README file) was resolved by emitting `README.md` from `README.md.hbs` and re-running the test suite successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956c3c412fc8325ba425a6e9e341b68)