### PR TITLE
Validate template migration graphs on load

### DIFF
--- a/packages/skaff-lib/src/core/templates/TemplateValidation.ts
+++ b/packages/skaff-lib/src/core/templates/TemplateValidation.ts
@@ -1,3 +1,4 @@
+import { TemplateMigration } from "@timonteutelink/template-types-lib";
 import semver from "semver";
 
 import { MAJOR_SPEC_VERSION } from "../../lib/constants";
@@ -45,11 +46,101 @@ export async function validateTemplateResources(template: Template): Promise<voi
   }
 }
 
+export function validateTemplateMigrations(template: Template): void {
+  const migrations = template.config.migrations;
+  if (!migrations || migrations.length === 0) {
+    return;
+  }
+
+  const templateName = template.config.templateConfig.name;
+  const seenUuids = new Set<string>();
+  for (const migration of migrations) {
+    if (seenUuids.has(migration.uuid)) {
+      throw new Error(
+        `Template ${templateName} has duplicate migration uuid "${migration.uuid}".`,
+      );
+    }
+    seenUuids.add(migration.uuid);
+  }
+
+  const migrationsByUuid = new Map(
+    migrations.map((migration) => [migration.uuid, migration]),
+  );
+
+  for (const migration of migrations) {
+    if (
+      migration.previousMigration &&
+      !migrationsByUuid.has(migration.previousMigration)
+    ) {
+      throw new Error(
+        `Template ${templateName} migration "${migration.uuid}" references missing previousMigration "${migration.previousMigration}".`,
+      );
+    }
+  }
+
+  const migrationsByPrevious = new Map<string | undefined, TemplateMigration[]>();
+  for (const migration of migrations) {
+    const list = migrationsByPrevious.get(migration.previousMigration) ?? [];
+    list.push(migration);
+    migrationsByPrevious.set(migration.previousMigration, list);
+  }
+
+  const roots = migrationsByPrevious.get(undefined) ?? [];
+  if (roots.length !== 1) {
+    if (roots.length === 0) {
+      throw new Error(
+        `Template ${templateName} migrations must have a single root migration with previousMigration undefined.`,
+      );
+    }
+
+    const rootList = roots.map((migration) => `"${migration.uuid}"`).join(", ");
+    throw new Error(
+      `Template ${templateName} has multiple root migrations: ${rootList}.`,
+    );
+  }
+
+  for (const [previousMigration, list] of migrationsByPrevious) {
+    if (list.length > 1) {
+      const forkList = list.map((migration) => `"${migration.uuid}"`).join(", ");
+      throw new Error(
+        `Template ${templateName} migration graph forks at previousMigration "${previousMigration ?? "undefined"}": ${forkList}.`,
+      );
+    }
+  }
+
+  const visited = new Set<string>();
+  let current = roots[0];
+  while (current) {
+    if (visited.has(current.uuid)) {
+      throw new Error(
+        `Template ${templateName} migration graph contains a cycle at "${current.uuid}".`,
+      );
+    }
+    visited.add(current.uuid);
+    const next = migrationsByPrevious.get(current.uuid)?.[0];
+    if (!next) {
+      break;
+    }
+    current = next;
+  }
+
+  if (visited.size !== migrations.length) {
+    const unreachable = migrations
+      .filter((migration) => !visited.has(migration.uuid))
+      .map((migration) => `"${migration.uuid}"`)
+      .join(", ");
+    throw new Error(
+      `Template ${templateName} has migrations not reachable from the root (cycle or disconnected chain): ${unreachable}.`,
+    );
+  }
+}
+
 export async function validateTemplate(template: Template): Promise<void> {
   validateTemplateSpecVersion(
     template.config.templateConfig.name,
     template.config.templateConfig.specVersion,
   );
 
+  validateTemplateMigrations(template);
   await validateTemplateResources(template);
 }

--- a/packages/skaff-lib/tests/template-migration-validation.test.ts
+++ b/packages/skaff-lib/tests/template-migration-validation.test.ts
@@ -1,0 +1,89 @@
+import path from "node:path";
+
+import type { TemplateMigration } from "@timonteutelink/template-types-lib";
+import z from "zod";
+
+import { Template } from "../src/core/templates/Template";
+import { validateTemplateMigrations } from "../src/core/templates/TemplateValidation";
+import type { GenericTemplateConfigModule } from "../src/lib/types";
+
+describe("validateTemplateMigrations", () => {
+  const baseDir = "/repo/templates";
+  const emptySchema = z.object({});
+  const noopMigrate = (settings: Record<string, unknown>) => settings;
+
+  const createTemplate = (migrations: TemplateMigration[]): Template => {
+    const config: GenericTemplateConfigModule = {
+      templateConfig: {
+        name: "sample-template",
+        author: "Test Author",
+        specVersion: "1.0.0",
+      },
+      templateSettingsSchema: emptySchema,
+      templateFinalSettingsSchema: emptySchema,
+      mapFinalSettings: ({ templateSettings }) => templateSettings,
+      migrations,
+    };
+
+    return new Template({
+      config,
+      absoluteBaseDir: baseDir,
+      absoluteDir: path.join(baseDir, "sample-template"),
+      absoluteFilesDir: path.join(baseDir, "sample-template", "files"),
+    });
+  };
+
+  it("throws when migration UUIDs are duplicated", () => {
+    const migrations: TemplateMigration[] = [
+      { uuid: "m1", migrate: noopMigrate },
+      { uuid: "m1", previousMigration: "m1", migrate: noopMigrate },
+    ];
+
+    const template = createTemplate(migrations);
+
+    expect(() => validateTemplateMigrations(template)).toThrow(
+      'Template sample-template has duplicate migration uuid "m1".',
+    );
+  });
+
+  it("throws when previousMigration references are missing", () => {
+    const migrations: TemplateMigration[] = [
+      { uuid: "m1", migrate: noopMigrate },
+      { uuid: "m2", previousMigration: "missing", migrate: noopMigrate },
+    ];
+
+    const template = createTemplate(migrations);
+
+    expect(() => validateTemplateMigrations(template)).toThrow(
+      'Template sample-template migration "m2" references missing previousMigration "missing".',
+    );
+  });
+
+  it("throws when multiple roots exist", () => {
+    const migrations: TemplateMigration[] = [
+      { uuid: "m1", migrate: noopMigrate },
+      { uuid: "m2", migrate: noopMigrate },
+    ];
+
+    const template = createTemplate(migrations);
+
+    expect(() => validateTemplateMigrations(template)).toThrow(
+      'Template sample-template has multiple root migrations: "m1", "m2".',
+    );
+  });
+
+  it("throws when migrations are not reachable from the root", () => {
+    const migrations: TemplateMigration[] = [
+      { uuid: "m1", migrate: noopMigrate },
+      { uuid: "m2", previousMigration: "m1", migrate: noopMigrate },
+      { uuid: "m3", previousMigration: "m4", migrate: noopMigrate },
+      { uuid: "m4", previousMigration: "m3", migrate: noopMigrate },
+    ];
+
+    const template = createTemplate(migrations);
+
+    expect(() => validateTemplateMigrations(template)).toThrow(
+      'Template sample-template has migrations not reachable from the root (cycle or disconnected chain): "m3", "m4".',
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure template migrations form a valid linear upgrade chain and fail fast when templates contain malformed migration graphs.
- Surface clear, actionable error messages that reference the template name and offending migration UUIDs to aid debugging.
- Run migration validation as part of template loading alongside spec version checks to prevent invalid templates from being used.

### Description
- Add `validateTemplateMigrations(template: Template)` to `packages/skaff-lib/src/core/templates/TemplateValidation.ts` which checks for duplicate `uuid`s, missing `previousMigration` references, multiple roots, forks, cycles, and unreachable migrations.  
- Import `TemplateMigration` from `@timonteutelink/template-types-lib` and call `validateTemplateMigrations` from `validateTemplate()` so validation runs when templates are loaded.  
- Add unit tests at `packages/skaff-lib/tests/template-migration-validation.test.ts` covering duplicate UUIDs, missing `previousMigration`, multiple roots, and disconnected/cycle cases.  
- Throw descriptive `Error` messages that include the template name and offending migration UUID(s) for each failure mode. 

### Testing
- Ran `bun run test:skaff-lib` which invokes the package build and tests, and it failed during TypeScript build with errors about missing exports in `@timonteutelink/template-types-lib` so the test suite did not run to completion.  
- Ran `cd packages/skaff-lib && bun run test` which likewise failed during the `tsc` build step with the same TypeScript errors, preventing Jest from running the new unit tests.  
- Added unit test file `packages/skaff-lib/tests/template-migration-validation.test.ts` but execution was blocked by the repository-wide type errors reported above.  
- All added unit tests are focused on invalid migration graphs and expect `validateTemplateMigrations` to throw the documented errors (unexecuted due to the build failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956dbe889088325be1e227fc5e8845c)