### PR TITLE
Seed web plugin stages with existing template settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ Templates may also include tasks, linting and formatting setups so that your new
   multiple plugins are enabled.
 - Plugins target the `TemplateGenerationPlugin` interface, which receives a `PipelineBuilder` seeded with the default stages so
   they can inject, replace or remove steps while keeping the base pipeline intact and deterministic when no plugins load.
+- CLI and Web plugin entrypoints can be exported as factories that receive `{ template, options, projectContext }`, allowing
+  UI hooks to use template-scoped plugin options alongside a safe template view and read-only project metadata.
 - Plugins can persist namespaced data under `instantiatedTemplates.<id>.plugins.<pluginName>` using the shared
   `TemplatePluginSettingsStore`; these values are written to `templateSettings.json` alongside other template settings.
 - CLI plugins can surface commands through `skaff plugin run --list` / `--command <name>` while web plugins return lightweight

--- a/apps/cli/src/utils/template-utils.ts
+++ b/apps/cli/src/utils/template-utils.ts
@@ -51,6 +51,10 @@ async function runStageSequence(
     const baseContext = {
       ...context,
       currentSettings: workingSettings,
+      settingsDraft: workingSettings,
+      setSettingsDraft: (next: UserTemplateSettings | null) => {
+        workingSettings = next ?? null
+      },
       stageState: stageState[key],
       setStageState: (value: unknown) => {
         stageState[key] = value

--- a/bun.lock
+++ b/bun.lock
@@ -170,16 +170,16 @@
       "dependencies": {
         "@timonteutelink/skaff-plugin-greeter": "workspace:*",
         "@timonteutelink/skaff-plugin-greeter-types": "workspace:*",
-        "react": "18.3.1",
+        "react": "19.2.0",
       },
       "devDependencies": {
         "@timonteutelink/skaff-lib": "workspace:*",
-        "@types/react": "18.3.11",
+        "@types/react": "19.2.5",
         "typescript": "5.9.3",
       },
       "peerDependencies": {
         "@timonteutelink/skaff-lib": ">=0.0.56",
-        "react": "^18.3.1",
+        "react": "^19.2.0",
       },
     },
     "packages/eslint-config": {
@@ -437,9 +437,9 @@
 
     "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
 
-    "@emnapi/core": ["@emnapi/core@1.7.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg=="],
+    "@emnapi/core": ["@emnapi/core@1.8.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-ryJnSmj4UhrGLZZPJ6PKVb4wNPAIkW6iyLy+0TRwazd3L1u0wzMe8RfqevAh2HbcSkoeLiSYnOVDOys4JSGYyg=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.8.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Z82FDl1ByxqPEPrAYYeTQVlx2FSHPe1qwX465c+96IRS3fTdSYRoJcRxg3g2fEG5I69z1dSEWQlNRRr0/677mg=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
 
@@ -1139,7 +1139,7 @@
 
     "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
 
-    "@types/react": ["@types/react@18.3.11", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.0.2" } }, "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ=="],
+    "@types/react": ["@types/react@19.2.5", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-keKxkZMqnDicuvFoJbzrhbtdLSPhj/rZThDlKWCDbgXmUg0rEUFtRssDXKYmtXluZlIqiC5VqkCgRwzuyLHKHw=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
@@ -2759,9 +2759,9 @@
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.7.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-ryJnSmj4UhrGLZZPJ6PKVb4wNPAIkW6iyLy+0TRwazd3L1u0wzMe8RfqevAh2HbcSkoeLiSYnOVDOys4JSGYyg=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-Z82FDl1ByxqPEPrAYYeTQVlx2FSHPe1qwX465c+96IRS3fTdSYRoJcRxg3g2fEG5I69z1dSEWQlNRRr0/677mg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
 
@@ -2780,8 +2780,6 @@
     "@types/babel__template/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
     "@types/babel__traverse/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
-
-    "@types/react-dom/@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -3316,8 +3314,6 @@
     "v8-to-istanbul/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "validate-npm-package-license/spdx-expression-parse": ["spdx-expression-parse@3.0.1", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q=="],
-
-    "web/@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 

--- a/packages/skaff-lib/src/browser.ts
+++ b/packages/skaff-lib/src/browser.ts
@@ -3,3 +3,4 @@ export * from './lib/types';
 export * from './lib/logger/types';
 export * from "./core/plugins/plugin-compatibility";
 export * from "./core/plugins/plugin-types";
+export * from "./core/plugins/template-view";

--- a/packages/skaff-lib/src/core/plugins/plugin-types.ts
+++ b/packages/skaff-lib/src/core/plugins/plugin-types.ts
@@ -558,7 +558,7 @@ export interface CliPluginContribution<TPrompts = CliPromptModule> {
 
 export type CliPluginEntrypoint<TPrompts = CliPromptModule> =
   | CliPluginContribution<TPrompts>
-  | (() =>
+  | ((input?: UiPluginFactoryInput) =>
       | CliPluginContribution<TPrompts>
       | Promise<CliPluginContribution<TPrompts>>);
 
@@ -586,7 +586,24 @@ export interface WebPluginContribution {
 
 export type WebPluginEntrypoint =
   | WebPluginContribution
-  | (() => WebPluginContribution | Promise<WebPluginContribution>);
+  | ((input?: UiPluginFactoryInput) =>
+      | WebPluginContribution
+      | Promise<WebPluginContribution>);
+
+/**
+ * Input provided to UI plugin factories (CLI/Web).
+ *
+ * Provides the same safe template view and template-scoped options used by
+ * template generation plugin factories, plus read-only project metadata.
+ */
+export interface UiPluginFactoryInput {
+  /** Read-only view of the template with minimal safe information */
+  template: TemplateView;
+  /** Plugin-specific options from the template configuration */
+  options?: unknown;
+  /** Read-only project metadata (name, author, root template) */
+  projectContext: ReadonlyProjectContext;
+}
 
 export interface NormalizedTemplatePluginConfig {
   module: string;
@@ -632,6 +649,10 @@ export interface BaseTemplateStageContext<TState = unknown> {
   projectRepositoryName?: string;
   /** Current user-provided settings (null before settings form) */
   currentSettings?: UserTemplateSettings | null;
+  /** Draft settings for the current template (if provided) */
+  settingsDraft?: UserTemplateSettings | null;
+  /** Update the draft template settings for the current template */
+  setSettingsDraft?: (next: UserTemplateSettings | null) => void;
   /**
    * Plugin-scoped state for this stage.
    * Automatically namespaced - plugins cannot see or modify other plugins' state.
@@ -653,6 +674,11 @@ export interface WebTemplateStageRenderProps<
    * State is automatically namespaced by plugin name to prevent collisions.
    */
   setStageState: (value: TState) => void;
+  /**
+   * Update the draft template settings for the current template.
+   * This does not modify other templates' settings.
+   */
+  setSettingsDraft: (next: UserTemplateSettings | null) => void;
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Allow web UI plugin stages to see and operate on the current template's settings when editing an existing template instance so plugins (e.g. ERD editors) can map settings → UI before the form renders. 
- Provide a template-scoped, read-only snapshot plus an editable `settingsDraft` so plugins cannot access other templates' instantiated data while still seeding sensible defaults. 
- Unify CLI and Web plugin factory inputs so UI factories receive the same safe `TemplateView`, `options` and `projectContext`. 
- Validate and surface draft settings to prevent invalid drafts from progressing through stage flows.

### Description
- Add `settingsDraft` and `setSettingsDraft` to `BaseTemplateStageContext` and `WebTemplateStageRenderProps`, and propagate these through the web instantiation flow so stages receive a draft and a setter. 
- Seed web stages with a read-only snapshot `readonlyStageSettings` (initialized from `project.settings.instantiatedTemplates` when editing) and prefer the `settingsDraft` when present; pages now call stage renderers with `currentSettings: readonlyStageSettings` and `setSettingsDraft`. 
- Introduce `UiPluginFactoryInput` and update plugin entrypoint types so CLI/Web factory functions receive `{ template, options, projectContext }`, and adapt `web-stage-loader` and core `plugin-loader` to pass that input when resolving UI contributions. 
- Implement draft schema normalization/validation in the web page with `normalizeNativeSchemaNode` / `buildSchemaAndDefaults`, plus helper `setDraftAndDefaults` and `validateSettingsDraft` to gate stage continuation.

### Testing
- Ran `make cr` and `bun install` to refresh the lockfile and dependencies (succeeded). 
- Built dependent packages with `cd packages/template-types-lib && bun run build` and `cd packages/skaff-lib && bun run build` (succeeded). 
- Ran the full unit/integration suite via `bun run test:skaff-lib` which completed successfully (`32` test suites, `209` tests passed). 
- Built the web app via `bun --filter ./apps/web build` which compiled and produced prerendered routes (web build exited with code 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695892a934048325984eb7949e799288)