### PR TITLE
Add CLI plugin-settings commands (get/set/remove) and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,18 @@ The CLI follows the standard `skaff <command> [options]` pattern. Common command
 
 Run `skaff --help` to see the full list of commands and flags.
 
+### Plugin settings
+
+The Web UI and CLI share the same system-wide plugin settings stored in
+`~/.config/skaff/settings.json`. Use these commands to manage per-plugin
+settings from the terminal:
+
+```bash
+skaff plugin-settings get
+skaff plugin-settings set @skaff/plugin-greeter '{"greeting":"Hello"}'
+skaff plugin-settings remove @skaff/plugin-greeter
+```
+
 ## Web interface
 
 In addition to the CLI, skaff provides a Web UI. The Web interface makes it easy to browse templates, enter values through forms, preview the file tree or diff and apply the changes interactively

--- a/apps/cli/src/commands/plugin-settings/get.ts
+++ b/apps/cli/src/commands/plugin-settings/get.ts
@@ -1,0 +1,54 @@
+import {Args} from '@oclif/core'
+import {getAllPluginSystemSettings, getPluginSystemSettings} from '@timonteutelink/skaff-lib'
+
+import Base from '../../base-command.js'
+import {getPluginNameValidationError} from '../../utils/plugin-settings.js'
+
+export default class PluginSettingsGet extends Base {
+  static description = 'Show system-wide settings for installed plugins'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> @skaff/plugin-greeter',
+    '<%= config.bin %> <%= command.id %> @skaff/plugin-greeter --format json',
+  ]
+
+  static args = {
+    pluginName: Args.string({
+      description: 'The plugin name to retrieve settings for',
+      required: false,
+    }),
+  }
+
+  async run(): Promise<void> {
+    const {args} = await this.parse(PluginSettingsGet)
+
+    if (args.pluginName) {
+      const validationError = getPluginNameValidationError(args.pluginName)
+      if (validationError) {
+        this.error(validationError, {exit: 1})
+      }
+
+      const settings = await getPluginSystemSettings(args.pluginName)
+      if (settings === undefined) {
+        this.error(`No system settings found for plugin "${args.pluginName}".`, {exit: 1})
+      }
+
+      await this.output({pluginName: args.pluginName, settings})
+      return
+    }
+
+    const settings = await getAllPluginSystemSettings()
+    const entries = Object.entries(settings).map(([pluginName, pluginSettings]) => ({
+      pluginName,
+      settings: pluginSettings,
+    }))
+
+    if (entries.length === 0) {
+      this.log('No plugin settings configured.')
+      return
+    }
+
+    await this.output(entries)
+  }
+}

--- a/apps/cli/src/commands/plugin-settings/remove.ts
+++ b/apps/cli/src/commands/plugin-settings/remove.ts
@@ -1,0 +1,32 @@
+import {Args} from '@oclif/core'
+import {removePluginSystemSettings} from '@timonteutelink/skaff-lib'
+
+import Base from '../../base-command.js'
+import {getPluginNameValidationError} from '../../utils/plugin-settings.js'
+
+export default class PluginSettingsRemove extends Base {
+  static description = 'Remove system-wide settings for a plugin'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> @skaff/plugin-greeter',
+  ]
+
+  static args = {
+    pluginName: Args.string({
+      description: 'The plugin name to remove settings for',
+      required: true,
+    }),
+  }
+
+  async run(): Promise<void> {
+    const {args} = await this.parse(PluginSettingsRemove)
+
+    const validationError = getPluginNameValidationError(args.pluginName)
+    if (validationError) {
+      this.error(validationError, {exit: 1})
+    }
+
+    await removePluginSystemSettings(args.pluginName)
+    this.log(`Removed plugin settings for ${args.pluginName}.`)
+  }
+}

--- a/apps/cli/src/commands/plugin-settings/set.ts
+++ b/apps/cli/src/commands/plugin-settings/set.ts
@@ -1,0 +1,44 @@
+import {Args} from '@oclif/core'
+import {setPluginSystemSettings} from '@timonteutelink/skaff-lib'
+
+import Base from '../../base-command.js'
+import {getPluginNameValidationError} from '../../utils/plugin-settings.js'
+
+export default class PluginSettingsSet extends Base {
+  static description = 'Save system-wide settings for a plugin'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> @skaff/plugin-greeter "{\"greeting\": \"Hello\"}"',
+    '<%= config.bin %> <%= command.id %> my-plugin "{\"enabled\": true}"',
+  ]
+
+  static args = {
+    pluginName: Args.string({
+      description: 'The plugin name to configure',
+      required: true,
+    }),
+    settings: Args.string({
+      description: 'JSON settings to store for the plugin',
+      required: true,
+    }),
+  }
+
+  async run(): Promise<void> {
+    const {args} = await this.parse(PluginSettingsSet)
+
+    const validationError = getPluginNameValidationError(args.pluginName)
+    if (validationError) {
+      this.error(validationError, {exit: 1})
+    }
+
+    let parsedSettings: unknown
+    try {
+      parsedSettings = JSON.parse(args.settings)
+    } catch {
+      this.error('Settings must be valid JSON', {exit: 1})
+    }
+
+    await setPluginSystemSettings(args.pluginName, parsedSettings)
+    this.log(`Saved plugin settings for ${args.pluginName}.`)
+  }
+}

--- a/apps/cli/src/utils/plugin-settings.ts
+++ b/apps/cli/src/utils/plugin-settings.ts
@@ -1,0 +1,13 @@
+const pluginNamePattern = /^[a-zA-Z0-9-_.:@/]+$/
+
+export function getPluginNameValidationError(pluginName: string): string | null {
+  if (!pluginName.trim()) {
+    return 'Plugin name is required'
+  }
+
+  if (!pluginNamePattern.test(pluginName)) {
+    return 'Plugin name can only contain alphanumeric characters, dashes, underscores, dots, colons, @ and /'
+  }
+
+  return null
+}

--- a/apps/cli/test/commands/plugin-settings/integration.test.ts
+++ b/apps/cli/test/commands/plugin-settings/integration.test.ts
@@ -1,0 +1,92 @@
+import {expect} from 'chai'
+import {captureOutput} from '@oclif/test'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+import {mkdtemp, readFile, rm} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+import sandboxModule from '../../../../../packages/skaff-lib/dist/core/infra/hardened-sandbox.js'
+
+const {markHardenedEnvironmentForTesting} = sandboxModule as {
+  markHardenedEnvironmentForTesting: () => void
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const cliRoot = path.resolve(__dirname, '..', '..', '..')
+
+type Fixture = {
+  root: string
+}
+
+async function readSettings(root: string): Promise<Record<string, unknown>> {
+  const raw = await readFile(path.join(root, 'settings.json'), 'utf8')
+  return JSON.parse(raw) as Record<string, unknown>
+}
+
+describe('cli plugin-settings commands', () => {
+  let fixture: Fixture
+  let originalEnv: NodeJS.ProcessEnv
+
+  beforeEach(async () => {
+    fixture = {root: await mkdtemp(path.join(tmpdir(), 'skaff-cli-plugin-settings-'))}
+    originalEnv = {...process.env}
+    process.env.SKAFF_CONFIG_PATH = fixture.root
+    markHardenedEnvironmentForTesting()
+  })
+
+  afterEach(async () => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key]
+      }
+    }
+    for (const [key, value] of Object.entries(originalEnv)) {
+      process.env[key] = value
+    }
+
+    await rm(fixture.root, {recursive: true, force: true})
+  })
+
+  it('saves and reads plugin settings', async () => {
+    const pluginName = '@skaff/plugin-greeter'
+    const settingsJson = '{"greeting":"Hello","enabled":true}'
+    const setModule = await import('../../../src/commands/plugin-settings/set.js')
+    const getModule = await import('../../../src/commands/plugin-settings/get.js')
+
+    const setResult = await captureOutput(() =>
+      setModule.default.run([pluginName, settingsJson], {root: cliRoot}),
+    )
+    expect(setResult.error).to.be.undefined
+
+    const storedSettings = await readSettings(fixture.root)
+    expect(storedSettings.plugins).to.deep.equal({
+      [pluginName]: {greeting: 'Hello', enabled: true},
+    })
+
+    const getResult = await captureOutput(() =>
+      getModule.default.run([pluginName, '--format', 'json'], {root: cliRoot}),
+    )
+    expect(getResult.error).to.be.undefined
+
+    const parsed = JSON.parse(getResult.stdout) as {
+      pluginName: string
+      settings: Record<string, unknown>
+    }
+    expect(parsed.pluginName).to.equal(pluginName)
+    expect(parsed.settings).to.deep.equal({greeting: 'Hello', enabled: true})
+  })
+
+  it('removes plugin settings', async () => {
+    const pluginName = '@skaff/plugin-greeter'
+    const settingsJson = '{"greeting":"Hello"}'
+    const setModule = await import('../../../src/commands/plugin-settings/set.js')
+    const removeModule = await import('../../../src/commands/plugin-settings/remove.js')
+
+    await captureOutput(() => setModule.default.run([pluginName, settingsJson], {root: cliRoot}))
+    const removeResult = await captureOutput(() => removeModule.default.run([pluginName], {root: cliRoot}))
+    expect(removeResult.error).to.be.undefined
+
+    const storedSettings = await readSettings(fixture.root)
+    expect(storedSettings.plugins).to.deep.equal({})
+  })
+})


### PR DESCRIPTION
### Motivation

- Provide CLI parity with the Web UI for managing system-wide per-plugin settings. 
- Expose the same store used by the web UI so plugin settings can be managed from the terminal. 
- Add validation and examples so CLI behaviour mirrors the Web UI. 
- Ensure settings are persisted to the existing `settings.json` file used by the library.

### Description

- Added new CLI commands `plugin-settings:get`, `plugin-settings:set` and `plugin-settings:remove` under `apps/cli/src/commands/plugin-settings/` that call `getPluginSystemSettings`, `setPluginSystemSettings` and `removePluginSystemSettings` from `@timonteutelink/skaff-lib`. 
- Added a small validation helper in `apps/cli/src/utils/plugin-settings.ts` to validate plugin names and surface helpful errors. 
- Added integration tests `apps/cli/test/commands/plugin-settings/integration.test.ts` that exercise saving, reading and removing plugin settings in `settings.json`. 
- Documented CLI usage in the root `README.md` and included usage examples mirroring the web UI.

### Testing

- Ran `cd apps/cli && bun run test:commands`; the new `plugin-settings` integration tests passed but some existing project integration tests still fail due to mismatched `template-types-lib` exports used by `packages/skaff-lib` (failure unrelated to the new commands). 
- Attempted `cd packages/skaff-lib && bun run test` which failed during build due to missing/renamed exports in `@timonteutelink/template-types-lib` (type/export compatibility issue). 
- The plugin-settings command smoke flow was verified locally by the integration tests which confirmed settings are written to and read from the configured `settings.json`. 
- No additional manual verification was performed beyond the automated tests above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69597143fecc8325a0890327f740e785)