### PR TITLE
Validate global plugin settings in plugin compatibility checks

### DIFF
--- a/apps/web/src/components/general/plugins/plugin-compatibility.tsx
+++ b/apps/web/src/components/general/plugins/plugin-compatibility.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import type { PluginCompatibilityResult } from "@/lib/plugins/web-stage-loader";
+import {
+  buildCompatibilitySummary,
+  buildWebInstallInstructions,
+  formatGlobalConfigIssue,
+  formatPluginMismatch,
+  formatPluginName,
+  formatPluginRequirement,
+  getCompatibilityBreakdown,
+} from "@/lib/plugins/plugin-compatibility-messages";
+
+interface PluginCompatibilitySummaryProps {
+  result: PluginCompatibilityResult;
+  showDetails?: boolean;
+}
+
+export function PluginCompatibilitySummary({
+  result,
+  showDetails = false,
+}: PluginCompatibilitySummaryProps) {
+  const { missing, versionMismatches, invalidGlobalConfig, totalRequired } =
+    getCompatibilityBreakdown(result);
+
+  const badgeLabel =
+    totalRequired === 0
+      ? "No plugins required"
+      : result.compatible
+        ? "Compatible"
+        : buildCompatibilitySummary(result);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <Badge variant={result.compatible ? "secondary" : "destructive"}>
+        {badgeLabel}
+      </Badge>
+      {showDetails && !result.compatible ? (
+        <div className="text-xs text-muted-foreground space-y-1">
+          {missing.length > 0 ? (
+            <p>Missing: {missing.map(formatPluginRequirement).join(", ")}</p>
+          ) : null}
+          {versionMismatches.length > 0 ? (
+            <p>
+              Version mismatches:{" "}
+              {versionMismatches.map(formatPluginMismatch).join(", ")}
+            </p>
+          ) : null}
+          {invalidGlobalConfig.length > 0 ? (
+            <p>
+              Invalid global settings:{" "}
+              {invalidGlobalConfig.map(formatGlobalConfigIssue).join(", ")}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+interface PluginCompatibilityDetailsProps {
+  result: PluginCompatibilityResult;
+  title?: string;
+}
+
+export function PluginCompatibilityDetails({
+  result,
+  title = "Plugin compatibility",
+}: PluginCompatibilityDetailsProps) {
+  const { missing, versionMismatches, invalidGlobalConfig, totalRequired } =
+    getCompatibilityBreakdown(result);
+
+  if (totalRequired === 0) {
+    return (
+      <section className="space-y-2">
+        <h3 className="text-lg font-semibold">{title}</h3>
+        <p className="text-sm text-muted-foreground">
+          No plugins are required by this template.
+        </p>
+      </section>
+    );
+  }
+
+  if (result.compatible) {
+    return (
+      <section className="space-y-2">
+        <h3 className="text-lg font-semibold">{title}</h3>
+        <p className="text-sm text-muted-foreground">
+          All required plugins are installed and compatible.
+        </p>
+      </section>
+    );
+  }
+
+  const missingSpecs = missing.map(formatPluginRequirement);
+  const mismatchSpecs = versionMismatches.map(formatPluginRequirement);
+  const missingInstall = buildWebInstallInstructions(missingSpecs);
+  const mismatchInstall = buildWebInstallInstructions(mismatchSpecs);
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-lg font-semibold">{title}</h3>
+      <Alert variant="destructive">
+        <AlertTitle>Missing or incompatible plugins</AlertTitle>
+        <AlertDescription className="space-y-3">
+          <p>
+            This template requires plugins that are not available in the current
+            Web UI build. Install or update the plugins and rebuild the Web UI
+            to continue.
+          </p>
+          {missing.length > 0 ? (
+            <div className="space-y-2">
+              <p className="font-medium text-sm">Missing plugins</p>
+              <ul className="list-disc pl-4 text-sm">
+                {missing.map((plugin) => (
+                  <li key={plugin.module}>{formatPluginRequirement(plugin)}</li>
+                ))}
+              </ul>
+              {missingInstall ? (
+                <div className="space-y-2 text-sm">
+                  <p className="font-medium">Install in Web builds with:</p>
+                  <pre className="bg-muted p-2 rounded text-xs">
+                    {missingInstall.docker}
+                  </pre>
+                  <pre className="bg-muted p-2 rounded text-xs">
+                    {missingInstall.nix}
+                  </pre>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+          {versionMismatches.length > 0 ? (
+            <div className="space-y-2">
+              <p className="font-medium text-sm">Version mismatches</p>
+              <ul className="list-disc pl-4 text-sm">
+                {versionMismatches.map((plugin) => (
+                  <li key={plugin.module}>{formatPluginMismatch(plugin)}</li>
+                ))}
+              </ul>
+              {mismatchInstall ? (
+                <div className="space-y-2 text-sm">
+                  <p className="font-medium">Rebuild with required versions:</p>
+                  <pre className="bg-muted p-2 rounded text-xs">
+                    {mismatchInstall.docker}
+                  </pre>
+                  <pre className="bg-muted p-2 rounded text-xs">
+                    {mismatchInstall.nix}
+                  </pre>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+          {invalidGlobalConfig.length > 0 ? (
+            <div className="space-y-2">
+              <p className="font-medium text-sm">
+                Invalid global plugin settings
+              </p>
+              <ul className="list-disc pl-4 text-sm">
+                {invalidGlobalConfig.map((plugin) => (
+                  <li key={plugin.module}>
+                    {formatGlobalConfigIssue(plugin)}
+                  </li>
+                ))}
+              </ul>
+              <div className="space-y-2 text-sm">
+                <p className="font-medium">Fix settings in the Web UI:</p>
+                <p>
+                  Open <span className="font-semibold">Settings</span> →{" "}
+                  <span className="font-semibold">Plugin Settings</span> and
+                  update the missing values.
+                </p>
+                <p className="font-medium">CLI alternative:</p>
+                <pre className="bg-muted p-2 rounded text-xs">
+                  {`skaff plugin-settings set ${invalidGlobalConfig
+                    .map((plugin) => formatPluginName(plugin))
+                    .join(" ")}`}
+                </pre>
+              </div>
+            </div>
+          ) : null}
+        </AlertDescription>
+      </Alert>
+    </section>
+  );
+}

--- a/apps/web/src/components/general/template-settings/template-settings-form.tsx
+++ b/apps/web/src/components/general/template-settings/template-settings-form.tsx
@@ -40,6 +40,8 @@ export const TemplateSettingsForm: React.FC<TemplateSettingsFormProps> = ({
   action,
   cancel,
   cancelButton,
+  submitDisabled,
+  submitDisabledReason,
 }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [zodSchema, setZodSchema] = useState<z.ZodType<any>>(z.object({}));
@@ -320,9 +322,19 @@ export const TemplateSettingsForm: React.FC<TemplateSettingsFormProps> = ({
                   Cancel
                 </Button>
               ) : null}
-              <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting ? "Saving..." : "Save settings"}
-              </Button>
+              <div className="flex flex-col items-end gap-2">
+                <Button
+                  type="submit"
+                  disabled={isSubmitting || submitDisabled}
+                >
+                  {isSubmitting ? "Saving..." : "Save settings"}
+                </Button>
+                {submitDisabledReason && submitDisabled ? (
+                  <p className="text-xs text-destructive text-right">
+                    {submitDisabledReason}
+                  </p>
+                ) : null}
+              </div>
             </div>
           </form>
         </Form>
@@ -330,4 +342,3 @@ export const TemplateSettingsForm: React.FC<TemplateSettingsFormProps> = ({
     </div>
   );
 };
-

--- a/apps/web/src/components/general/template-settings/types.ts
+++ b/apps/web/src/components/general/template-settings/types.ts
@@ -11,6 +11,8 @@ export interface TemplateSettingsFormProps {
   action: (userSettings: any) => Promise<void>;
   cancel?: () => void;
   cancelButton?: ReactNode;
+  submitDisabled?: boolean;
+  submitDisabledReason?: string;
 }
 
 export interface SchemaResult {

--- a/apps/web/src/lib/plugins/plugin-compatibility-messages.test.ts
+++ b/apps/web/src/lib/plugins/plugin-compatibility-messages.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "bun:test";
+import type { PluginCompatibilityResult } from "./web-stage-loader";
+import {
+  buildCompatibilitySummary,
+  buildWebInstallInstructions,
+  formatGlobalConfigIssue,
+  formatPluginMismatch,
+  formatPluginRequirement,
+  getCompatibilityBreakdown,
+} from "./plugin-compatibility-messages";
+
+describe("plugin compatibility messages", () => {
+  it("summarizes templates without required plugins", () => {
+    const result: PluginCompatibilityResult = {
+      compatible: true,
+      missing: [],
+      available: [],
+      hasTrustWarnings: false,
+      untrustedPlugins: [],
+    };
+
+    expect(buildCompatibilitySummary(result)).toBe("No plugins required");
+  });
+
+  it("summarizes compatible templates with required plugins", () => {
+    const result: PluginCompatibilityResult = {
+      compatible: true,
+      missing: [],
+      available: [
+        {
+          name: "@skaff/plugin-foo",
+          packageName: "@skaff/plugin-foo",
+          version: "1.0.0",
+          trustLevel: "official",
+        },
+      ],
+      hasTrustWarnings: false,
+      untrustedPlugins: [],
+    };
+
+    expect(buildCompatibilitySummary(result)).toBe(
+      "All 1 required plugin(s) are compatible",
+    );
+  });
+
+  it("formats missing and mismatched plugins with versions", () => {
+    const result: PluginCompatibilityResult = {
+      compatible: false,
+      missing: [
+        {
+          module: "@skaff/plugin-foo",
+          requiredVersion: "^1.2.0",
+          reason: "not_installed",
+        },
+        {
+          module: "@skaff/plugin-bar",
+          requiredVersion: "^2.0.0",
+          installedVersion: "1.5.0",
+          reason: "version_mismatch",
+        },
+        {
+          module: "@skaff/plugin-baz",
+          reason: "invalid_global_config",
+          message: "Invalid global config for plugin @skaff/plugin-baz",
+        },
+      ],
+      available: [],
+      hasTrustWarnings: false,
+      untrustedPlugins: [],
+    };
+
+    const breakdown = getCompatibilityBreakdown(result);
+    expect(breakdown.missing).toHaveLength(1);
+    expect(breakdown.versionMismatches).toHaveLength(1);
+    expect(breakdown.invalidGlobalConfig).toHaveLength(1);
+    expect(formatPluginRequirement(breakdown.missing[0]!)).toBe(
+      "@skaff/plugin-foo@^1.2.0",
+    );
+    expect(formatPluginMismatch(breakdown.versionMismatches[0]!)).toBe(
+      "@skaff/plugin-bar: installed v1.5.0, requires ^2.0.0",
+    );
+    expect(formatGlobalConfigIssue(breakdown.invalidGlobalConfig[0]!)).toBe(
+      "@skaff/plugin-baz: Invalid global config for plugin @skaff/plugin-baz",
+    );
+  });
+
+  it("builds web install instructions for missing plugins", () => {
+    const instructions = buildWebInstallInstructions([
+      "@skaff/plugin-foo@^1.2.0",
+      "@skaff/plugin-bar",
+    ]);
+
+    expect(instructions?.docker).toBe(
+      'SKAFF_PLUGINS="@skaff/plugin-foo@^1.2.0 @skaff/plugin-bar"',
+    );
+    expect(instructions?.nix).toBe(
+      'plugins = [ "@skaff/plugin-foo@^1.2.0" "@skaff/plugin-bar" ]',
+    );
+  });
+
+  it("summarizes invalid global settings", () => {
+    const result: PluginCompatibilityResult = {
+      compatible: false,
+      missing: [
+        {
+          module: "@skaff/plugin-baz",
+          reason: "invalid_global_config",
+          message: "Invalid global config for plugin @skaff/plugin-baz",
+        },
+      ],
+      available: [],
+      hasTrustWarnings: false,
+      untrustedPlugins: [],
+    };
+
+    expect(buildCompatibilitySummary(result)).toBe(
+      "Invalid global settings (1)",
+    );
+  });
+});

--- a/apps/web/src/lib/plugins/plugin-compatibility-messages.ts
+++ b/apps/web/src/lib/plugins/plugin-compatibility-messages.ts
@@ -1,0 +1,117 @@
+import { extractPluginName } from "@timonteutelink/skaff-lib/browser";
+import type {
+  MissingPluginInfo,
+  PluginCompatibilityResult,
+} from "./web-stage-loader";
+
+export interface PluginCompatibilityBreakdown {
+  missing: MissingPluginInfo[];
+  versionMismatches: MissingPluginInfo[];
+  invalidGlobalConfig: MissingPluginInfo[];
+  totalRequired: number;
+}
+
+export function getCompatibilityBreakdown(
+  result: PluginCompatibilityResult,
+): PluginCompatibilityBreakdown {
+  const missing = result.missing.filter(
+    (plugin) => plugin.reason === "not_installed",
+  );
+  const versionMismatches = result.missing.filter(
+    (plugin) => plugin.reason === "version_mismatch",
+  );
+  const invalidGlobalConfig = result.missing.filter(
+    (plugin) => plugin.reason === "invalid_global_config",
+  );
+  const totalRequired =
+    missing.length +
+    versionMismatches.length +
+    invalidGlobalConfig.length +
+    result.available.length;
+
+  return { missing, versionMismatches, invalidGlobalConfig, totalRequired };
+}
+
+export function formatPluginRequirement(plugin: MissingPluginInfo): string {
+  const baseName = extractPluginName(plugin.module);
+  return plugin.requiredVersion
+    ? `${baseName}@${plugin.requiredVersion}`
+    : baseName;
+}
+
+export function formatPluginName(plugin: MissingPluginInfo): string {
+  return extractPluginName(plugin.module);
+}
+
+export function formatPluginMismatch(plugin: MissingPluginInfo): string {
+  const baseName = extractPluginName(plugin.module);
+  const installed = plugin.installedVersion
+    ? `v${plugin.installedVersion}`
+    : "an unknown version";
+  const required = plugin.requiredVersion ?? "an unspecified version";
+  return `${baseName}: installed ${installed}, requires ${required}`;
+}
+
+export function formatGlobalConfigIssue(plugin: MissingPluginInfo): string {
+  const baseName = extractPluginName(plugin.module);
+  return plugin.message
+    ? `${baseName}: ${plugin.message}`
+    : `${baseName}: invalid global settings`;
+}
+
+export function buildCompatibilitySummary(
+  result: PluginCompatibilityResult,
+): string {
+  const { missing, versionMismatches, invalidGlobalConfig, totalRequired } =
+    getCompatibilityBreakdown(result);
+
+  if (totalRequired === 0) {
+    return "No plugins required";
+  }
+
+  if (result.compatible) {
+    return `All ${totalRequired} required plugin(s) are compatible`;
+  }
+
+  if (
+    missing.length > 0 &&
+    versionMismatches.length > 0 &&
+    invalidGlobalConfig.length > 0
+  ) {
+    return `Missing plugins (${missing.length}), version mismatches (${versionMismatches.length}), and invalid global settings (${invalidGlobalConfig.length})`;
+  }
+
+  if (missing.length > 0 && versionMismatches.length > 0) {
+    return `Missing plugins (${missing.length}) and version mismatches (${versionMismatches.length})`;
+  }
+
+  if (missing.length > 0 && invalidGlobalConfig.length > 0) {
+    return `Missing plugins (${missing.length}) and invalid global settings (${invalidGlobalConfig.length})`;
+  }
+
+  if (versionMismatches.length > 0 && invalidGlobalConfig.length > 0) {
+    return `Version mismatches (${versionMismatches.length}) and invalid global settings (${invalidGlobalConfig.length})`;
+  }
+
+  if (missing.length > 0) {
+    return `Missing plugins (${missing.length})`;
+  }
+
+  if (invalidGlobalConfig.length > 0) {
+    return `Invalid global settings (${invalidGlobalConfig.length})`;
+  }
+
+  return `Version mismatches (${versionMismatches.length})`;
+}
+
+export function buildWebInstallInstructions(
+  specs: string[],
+): { docker: string; nix: string } | null {
+  if (specs.length === 0) {
+    return null;
+  }
+
+  const docker = `SKAFF_PLUGINS="${specs.join(" ")}"`;
+  const nix = `plugins = [ ${specs.map((spec) => `"${spec}"`).join(" ")} ]`;
+  return { docker, nix };
+}

--- a/packages/skaff-lib/tests/plugin-compatibility.test.ts
+++ b/packages/skaff-lib/tests/plugin-compatibility.test.ts
@@ -202,6 +202,7 @@ describe("plugin-compatibility", () => {
 
       expect(result.allCompatible).toBe(true);
       expect(result.plugins).toHaveLength(0);
+      expect(result.invalidGlobalConfig).toHaveLength(0);
     });
 
     it("should return allCompatible true when all plugins are compatible", () => {
@@ -222,6 +223,7 @@ describe("plugin-compatibility", () => {
       expect(result.compatible).toHaveLength(2);
       expect(result.missing).toHaveLength(0);
       expect(result.versionMismatches).toHaveLength(0);
+      expect(result.invalidGlobalConfig).toHaveLength(0);
     });
 
     it("should identify missing plugins", () => {
@@ -237,6 +239,7 @@ describe("plugin-compatibility", () => {
       expect(result.allCompatible).toBe(false);
       expect(result.missing).toHaveLength(1);
       expect(result.missing[0].module).toBe("@skaff/plugin-b");
+      expect(result.invalidGlobalConfig).toHaveLength(0);
     });
 
     it("should identify version mismatches", () => {
@@ -257,6 +260,7 @@ describe("plugin-compatibility", () => {
       expect(result.compatible).toHaveLength(1);
       expect(result.versionMismatches).toHaveLength(1);
       expect(result.versionMismatches[0].module).toBe("@skaff/plugin-b");
+      expect(result.invalidGlobalConfig).toHaveLength(0);
     });
   });
 
@@ -267,6 +271,7 @@ describe("plugin-compatibility", () => {
         plugins: [],
         missing: [],
         versionMismatches: [],
+        invalidGlobalConfig: [],
         compatible: [],
       });
 
@@ -282,6 +287,7 @@ describe("plugin-compatibility", () => {
         ],
         missing: [],
         versionMismatches: [],
+        invalidGlobalConfig: [],
         compatible: [
           { module: "a", compatible: true },
           { module: "b", compatible: true },
@@ -309,6 +315,7 @@ describe("plugin-compatibility", () => {
           },
         ],
         versionMismatches: [],
+        invalidGlobalConfig: [],
         compatible: [],
       });
 
@@ -338,12 +345,41 @@ describe("plugin-compatibility", () => {
             requiredVersion: "^2.0.0",
           },
         ],
+        invalidGlobalConfig: [],
         compatible: [],
       });
 
       expect(summary).toContain("Version mismatches (1):");
       expect(summary).toContain("installed v1.0.0");
       expect(summary).toContain("requires ^2.0.0");
+    });
+
+    it("should format invalid global settings", () => {
+      const summary = formatCompatibilitySummary({
+        allCompatible: false,
+        plugins: [
+          {
+            module: "@skaff/plugin-foo",
+            compatible: false,
+            reason: "invalid_global_config",
+            message: "Invalid global config for plugin @skaff/plugin-foo",
+          },
+        ],
+        missing: [],
+        versionMismatches: [],
+        invalidGlobalConfig: [
+          {
+            module: "@skaff/plugin-foo",
+            compatible: false,
+            reason: "invalid_global_config",
+            message: "Invalid global config for plugin @skaff/plugin-foo",
+          },
+        ],
+        compatible: [],
+      });
+
+      expect(summary).toContain("Invalid global plugin settings (1):");
+      expect(summary).toContain("Invalid global config for plugin");
     });
   });
 });


### PR DESCRIPTION
### Motivation
- Ensure plugin compatibility checks consider system-wide (global) plugin settings so plugins with incomplete or invalid global configuration are treated as unusable. 
- Surface invalid global plugin settings in both CLI and Web UI so users can take corrective action before attempting template instantiation. 
- Prevent Web UI template instantiation when required plugins are present but their global settings are invalid, mirroring CLI blocking behavior. 
- Provide actionable remediation: CLI commands and Web UI guidance for fixing plugin settings or rebuilding with required plugin versions.

### Description
- Extended the compatibility model to include `invalid_global_config` in `packages/skaff-lib` by updating `plugin-compatibility.ts` to accept an optional `validateGlobalConfig` hook and propagate invalid-global-config results into `TemplatePluginCompatibilityResult` and summaries. 
- Added `resolveRegisteredPluginModule` helper in `plugin-loader.ts` to safely load registered plugin modules for schema validation, and used it from the CLI to validate plugin `globalConfigSchema` against stored system settings. 
- Web UI integration: updated `apps/web` to load plugin system settings and pass them to `checkPluginCompatibility()` in `web-stage-loader.ts`, added `validateGlobalPluginSettings()` to validate `globalConfigSchema`, and surfaced invalid-global-config messages in the UI with new components/helpers under `apps/web/src/components/general/plugins` and `apps/web/src/lib/plugins/plugin-compatibility-messages.ts`. 
- UI/UX adjustments: changed template list, template details, and instantiation flows to fetch plugin settings, display compatibility state (including invalid global settings), and disable/annotate the template settings submit action when compatibility or global settings validation fails.

### Testing
- Ran `cd packages/skaff-lib && bun run test` which failed with a type resolution error: `Cannot find module '@timonteutelink/template-types-lib'`, so unit test suite did not complete. 
- Generated the Web plugin registry with `bun --cwd apps/web run generate:plugins` which completed and produced `generated-plugin-registry.ts` and `plugin-manifest.json` (no web plugins discovered). 
- Attempted to start the Web dev server with `bun --cwd apps/web dev` / `bun run dev` which failed because `next` was not available (`next: command not found`), so no live UI verification was possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69597b0dcc70832584b012ec57768757)