### PR TITLE
Align plugin stages to write into template settings and surface schema warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ Templates may also include tasks, linting and formatting setups so that your new
   UI hooks to use template-scoped plugin options alongside a safe template view and read-only project metadata.
 - Template settings are the single source of truth; plugins can surface UI or CLI stages to suggest or update settings, while
   templates own the schema that gets persisted to `templateSettings.json`.
+- Plugins can export a `requiredTemplateSettingsSchema` that templates should merge or extend into their own
+  `templateSettingsSchema` (for example, `templateSettingsSchema.merge(pluginRequiredSchema)`), ensuring plugin-required
+  fields are validated. Skaff warns when a template does not satisfy a plugin’s required settings schema.
 - CLI plugins can surface commands through `skaff plugin run --list` / `--command <name>` while web plugins return lightweight
   notices that the UI can render next to project details.
 - Template authors who publish plugin-specific type helpers can keep them separate from runtime code—for example, the

--- a/apps/cli/src/commands/project/new.ts
+++ b/apps/cli/src/commands/project/new.ts
@@ -3,7 +3,11 @@ import * as skaffLib from '@timonteutelink/skaff-lib'
 
 import Base from '../../base-command.js'
 import {viewParsedDiffWithGit} from '../../utils/diff-utils.js'
-import {checkTemplatePluginsCompatibility, formatPluginCompatibilityForCli} from '../../utils/plugin-manager.js'
+import {
+  checkTemplatePluginsCompatibility,
+  formatPluginCompatibilityForCli,
+  formatTemplateSettingsWarningsForCli,
+} from '../../utils/plugin-manager.js'
 import {readUserTemplateSettings} from '../../utils/template-utils.js'
 
 export default class InstantiationProjectNew extends Base {
@@ -56,7 +60,11 @@ export default class InstantiationProjectNew extends Base {
 
       const plugins = templateData.template.config.plugins
       if (plugins && plugins.length > 0) {
-        const compatibility = await checkTemplatePluginsCompatibility(this.config, plugins)
+        const compatibility = await checkTemplatePluginsCompatibility(
+          this.config,
+          plugins,
+          templateData.template.config.templateSettingsSchema,
+        )
 
         if (!compatibility.allCompatible) {
           this.log('Plugin compatibility check failed:')
@@ -65,6 +73,10 @@ export default class InstantiationProjectNew extends Base {
             'Cannot create project: missing or incompatible plugins. Use --skip-plugin-check to bypass this check.',
             {exit: 1},
           )
+        }
+
+        if (compatibility.templateSettingsWarnings.length > 0) {
+          this.warn(formatTemplateSettingsWarningsForCli(compatibility.templateSettingsWarnings))
         }
       }
     }

--- a/apps/cli/src/commands/template/list.ts
+++ b/apps/cli/src/commands/template/list.ts
@@ -47,7 +47,11 @@ export default class TemplateList extends Base {
         let missingPlugins = ''
 
         if (template.config.plugins && template.config.plugins.length > 0) {
-          const compatibility = await checkTemplatePluginsCompatibility(this.config, template.config.plugins)
+          const compatibility = await checkTemplatePluginsCompatibility(
+            this.config,
+            template.config.plugins,
+            template.config.templateSettingsSchema,
+          )
 
           if (!compatibility.allCompatible) {
             pluginStatus = 'plugins-missing'

--- a/apps/cli/src/utils/template-utils.ts
+++ b/apps/cli/src/utils/template-utils.ts
@@ -42,7 +42,11 @@ async function runStageSequence(
       currentSettings: workingSettings,
       settingsDraft: workingSettings,
       setSettingsDraft: (next: UserTemplateSettings | null) => {
-        workingSettings = next ?? null
+        if (!next) {
+          workingSettings = null
+          return
+        }
+        workingSettings = mergeUserSettings(next, workingSettings)
       },
       stageState: stageState[key],
       setStageState: (value: unknown) => {
@@ -188,7 +192,6 @@ export async function readUserTemplateSettings(
 ): Promise<UserTemplateSettings> {
   if (!arg) return promptUserTemplateSettings(rootTemplateName, templateName, defaults, options)
   const parsedSettings = fs.existsSync(arg) ? JSON.parse(fs.readFileSync(arg, 'utf8')) : JSON.parse(arg)
-
   const rootTpl = await skaffLib.getTemplate(rootTemplateName)
   if ('error' in rootTpl) throw new Error(rootTpl.error)
   if (!rootTpl.data) throw new Error(`No template named "${rootTemplateName}"`)

--- a/apps/web/src/app/projects/instantiate-template/page.tsx
+++ b/apps/web/src/app/projects/instantiate-template/page.tsx
@@ -119,7 +119,6 @@ const TemplateInstantiationPage: React.FC = () => {
     useState<UserTemplateSettings | null>(null);
   const [pendingFinalizeSettings, setPendingFinalizeSettings] =
     useState<UserTemplateSettings | null>(null);
-
   useEffect(() => {
     if (!projectRepositoryNameParam) {
       toastNullError({
@@ -753,10 +752,19 @@ const TemplateInstantiationPage: React.FC = () => {
 
   const setDraftAndDefaults = useCallback(
     (next: UserTemplateSettings | null) => {
-      setSettingsDraft(next);
-      setStoredFormData(next);
+      if (!next) {
+        setSettingsDraft(null);
+        setStoredFormData(null);
+        return;
+      }
+      const merged = {
+        ...(settingsDraft ?? storedFormData ?? {}),
+        ...next,
+      };
+      setSettingsDraft(merged);
+      setStoredFormData(merged);
     },
-    [],
+    [settingsDraft, storedFormData],
   );
 
   const validateSettingsDraft = useCallback(() => {

--- a/apps/web/src/components/general/plugins/plugin-compatibility.tsx
+++ b/apps/web/src/components/general/plugins/plugin-compatibility.tsx
@@ -10,6 +10,7 @@ import {
   formatPluginMismatch,
   formatPluginName,
   formatPluginRequirement,
+  formatTemplateSettingsWarning,
   getCompatibilityBreakdown,
 } from "@/lib/plugins/plugin-compatibility-messages";
 
@@ -22,8 +23,13 @@ export function PluginCompatibilitySummary({
   result,
   showDetails = false,
 }: PluginCompatibilitySummaryProps) {
-  const { missing, versionMismatches, invalidGlobalConfig, totalRequired } =
-    getCompatibilityBreakdown(result);
+  const {
+    missing,
+    versionMismatches,
+    invalidGlobalConfig,
+    totalRequired,
+    templateSettingsWarnings,
+  } = getCompatibilityBreakdown(result);
 
   const badgeLabel =
     totalRequired === 0
@@ -90,6 +96,20 @@ export function PluginCompatibilityDetails({
         <p className="text-sm text-muted-foreground">
           All required plugins are installed and compatible.
         </p>
+        {templateSettingsWarnings.length > 0 ? (
+          <Alert>
+            <AlertTitle>Template settings warnings</AlertTitle>
+            <AlertDescription>
+              <ul className="list-disc pl-4 text-sm">
+                {templateSettingsWarnings.map((warning) => (
+                  <li key={warning.module}>
+                    {formatTemplateSettingsWarning(warning)}
+                  </li>
+                ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        ) : null}
       </section>
     );
   }
@@ -182,6 +202,25 @@ export function PluginCompatibilityDetails({
           ) : null}
         </AlertDescription>
       </Alert>
+      {templateSettingsWarnings.length > 0 ? (
+        <Alert>
+          <AlertTitle>Template settings warnings</AlertTitle>
+          <AlertDescription>
+            <p>
+              This template does not fully satisfy plugin-required settings
+              schemas. Extend the template&apos;s settings schema to match the
+              plugin requirements.
+            </p>
+            <ul className="list-disc pl-4 text-sm">
+              {templateSettingsWarnings.map((warning) => (
+                <li key={warning.module}>
+                  {formatTemplateSettingsWarning(warning)}
+                </li>
+              ))}
+            </ul>
+          </AlertDescription>
+        </Alert>
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/lib/plugins/plugin-compatibility-messages.test.ts
+++ b/apps/web/src/lib/plugins/plugin-compatibility-messages.test.ts
@@ -15,6 +15,7 @@ describe("plugin compatibility messages", () => {
       compatible: true,
       missing: [],
       available: [],
+      templateSettingsWarnings: [],
       hasTrustWarnings: false,
       untrustedPlugins: [],
     };
@@ -34,6 +35,7 @@ describe("plugin compatibility messages", () => {
           trustLevel: "official",
         },
       ],
+      templateSettingsWarnings: [],
       hasTrustWarnings: false,
       untrustedPlugins: [],
     };
@@ -65,6 +67,7 @@ describe("plugin compatibility messages", () => {
         },
       ],
       available: [],
+      templateSettingsWarnings: [],
       hasTrustWarnings: false,
       untrustedPlugins: [],
     };
@@ -109,6 +112,7 @@ describe("plugin compatibility messages", () => {
         },
       ],
       available: [],
+      templateSettingsWarnings: [],
       hasTrustWarnings: false,
       untrustedPlugins: [],
     };

--- a/apps/web/src/lib/plugins/plugin-compatibility-messages.ts
+++ b/apps/web/src/lib/plugins/plugin-compatibility-messages.ts
@@ -8,6 +8,7 @@ export interface PluginCompatibilityBreakdown {
   missing: MissingPluginInfo[];
   versionMismatches: MissingPluginInfo[];
   invalidGlobalConfig: MissingPluginInfo[];
+  templateSettingsWarnings: PluginCompatibilityResult["templateSettingsWarnings"];
   totalRequired: number;
 }
 
@@ -29,7 +30,13 @@ export function getCompatibilityBreakdown(
     invalidGlobalConfig.length +
     result.available.length;
 
-  return { missing, versionMismatches, invalidGlobalConfig, totalRequired };
+  return {
+    missing,
+    versionMismatches,
+    invalidGlobalConfig,
+    templateSettingsWarnings: result.templateSettingsWarnings,
+    totalRequired,
+  };
 }
 
 export function formatPluginRequirement(plugin: MissingPluginInfo): string {
@@ -57,6 +64,12 @@ export function formatGlobalConfigIssue(plugin: MissingPluginInfo): string {
   return plugin.message
     ? `${baseName}: ${plugin.message}`
     : `${baseName}: invalid global settings`;
+}
+
+export function formatTemplateSettingsWarning(
+  warning: PluginCompatibilityResult["templateSettingsWarnings"][number],
+): string {
+  return warning.message;
 }
 
 export function buildCompatibilitySummary(

--- a/examples/plugins/plugin-greeter-cli/src/index.ts
+++ b/examples/plugins/plugin-greeter-cli/src/index.ts
@@ -55,6 +55,7 @@ const greeterCliInitStage: CliTemplateStage<
       default: "Hello from greeter!",
     });
     setStageState({ message });
+    return { greeter_message: message };
   },
 };
 

--- a/examples/plugins/plugin-greeter-types/README.md
+++ b/examples/plugins/plugin-greeter-types/README.md
@@ -15,8 +15,7 @@ export const templateConfig = {
 
 ## Exports
 
-- **`GREETER_PLUGIN_NAME`** – shared name for plugin-scoped settings.
-- **`GREETER_STAGE_STATE_KEY`** – default state key for before/after stages.
+- **`GREETER_PLUGIN_NAME`** – shared name for the greeter plugin manifest.
 - **`greeterTemplatePluginSpecifier`**, **`greeterCliPluginSpecifier`**,
   **`greeterWebPluginSpecifier`** – module specifiers for the individual
   runtime packages.

--- a/examples/plugins/plugin-greeter-web/src/index.tsx
+++ b/examples/plugins/plugin-greeter-web/src/index.tsx
@@ -13,7 +13,7 @@ type GreeterStageState = { disabled?: boolean; message?: string };
 const greeterInitWebStage: WebTemplateStage = {
   id: "greeter-init",
   placement: "init",
-  render: ({ onContinue, stageState, setStageState }) => {
+  render: ({ onContinue, stageState, setStageState, setSettingsDraft }) => {
     const typedState = stageState as GreeterStageState | undefined;
     const [message, setMessage] = useState(
       typeof typedState?.message === "string"
@@ -35,6 +35,7 @@ const greeterInitWebStage: WebTemplateStage = {
             const next = event.target.value;
             setMessage(next);
             setStageState({ message: next });
+            setSettingsDraft({ greeter_message: next });
           }}
         />
         <button

--- a/examples/plugins/plugin-greeter/README.md
+++ b/examples/plugins/plugin-greeter/README.md
@@ -1,9 +1,8 @@
 # Skaff greeter plugin
 
 A reference template-generation plugin that logs a friendly greeting during
-instantiation and stores plugin-scoped data in `templateSettings.json`. The CLI
-and web contributions live in sibling packages so React and Inquirer stay
-isolated:
+instantiation and updates the template settings directly. The CLI and web
+contributions live in sibling packages so React and Inquirer stay isolated:
 
 - `@timonteutelink/skaff-plugin-greeter` – template generation hook
 - `@timonteutelink/skaff-plugin-greeter-cli` – CLI commands and interactive
@@ -25,9 +24,10 @@ export const templateConfig = {
 };
 ```
 
-When the template instantiates, the base plugin logs a greeting and stores its
-state under `instantiatedTemplates.<id>.plugins.greeter` inside
-`templateSettings.json`.
+When the template instantiates, the base plugin logs a greeting and the CLI/web
+stages write `greeter_message` into the template settings. Templates should
+include `greeter_message` in their `templateSettingsSchema` if they want to keep
+the value.
 
 The CLI package exposes a `greet` command via `skaff plugin run --list` and adds
 before/after settings stages. The web package renders the same stages as React

--- a/examples/test-templates/test-template-repo/templates/test-template/templateConfig.ts
+++ b/examples/test-templates/test-template-repo/templates/test-template/templateConfig.ts
@@ -20,6 +20,10 @@ const templateSettingsSchema = z.object({
     .max(100)
     .default(21)
     .describe("A number to test with"),
+  greeter_message: z
+    .string()
+    .optional()
+    .describe("A greeting message provided by the greeter plugin"),
   test_object: z.object({
     test_array: z
       .array(

--- a/packages/skaff-lib/src/core/plugins/plugin-types.ts
+++ b/packages/skaff-lib/src/core/plugins/plugin-types.ts
@@ -769,6 +769,14 @@ export interface SkaffPluginModule {
    */
   globalConfigSchema?: z.ZodType<PluginGlobalConfig>;
 
+  /**
+   * Optional schema for template settings required by this plugin.
+   *
+   * Templates should merge/extend this schema into their own templateSettingsSchema
+   * to ensure required plugin settings are present and validated.
+   */
+  requiredTemplateSettingsSchema?: z.ZodObject<UserTemplateSettings>;
+
   /** Template generation plugin entrypoint */
   template?: TemplatePluginEntrypoint;
 

--- a/packages/template-types-lib/README.md
+++ b/packages/template-types-lib/README.md
@@ -61,6 +61,20 @@ Plugin settings live in the template’s own `templateSettingsSchema`. Plugins c
 read and suggest settings through their CLI/Web stages, while templates remain
 the single source of truth for stored settings.
 
+If a plugin exports a `requiredTemplateSettingsSchema`, import it in your
+template and merge/extend it into `templateSettingsSchema` so plugin-required
+fields are validated. For example:
+
+```ts
+import { requiredTemplateSettingsSchema as greeterRequired } from "@timonteutelink/skaff-plugin-greeter";
+
+const templateSettingsSchema = z
+  .object({
+    greeting: z.string().default("hello"),
+  })
+  .merge(greeterRequired);
+```
+
 ## Template Layout Example
 
 Templates often follow a layered structure where the root `templateConfig.ts` defines global settings and delegates to optional


### PR DESCRIPTION
### Motivation

- Unify plugin stage behavior so CLI and Web stages update the template's `UserTemplateSettings` directly (no `plugins` namespacing).
- Allow plugins to declare `requiredTemplateSettingsSchema` and surface actionable warnings when a template's settings schema does not satisfy plugin requirements.
- Simplify UI/CLI interactions by merging plugin stage output into the normal draft settings flow.
- Update example plugins and docs to demonstrate writing standard template keys instead of plugin-scoped keys.

### Description

- Merge plugin stage outputs directly into template settings in the CLI by changing `setSettingsDraft` behavior in `apps/cli/src/utils/template-utils.ts` to merge updates into `workingSettings`.
- Merge web UI stage outputs into the draft/settings state by updating `setDraftAndDefaults` in `apps/web/src/app/projects/instantiate-template/page.tsx` and wiring `setSettingsDraft` into web stages in `examples/plugins/plugin-greeter-web`.
- Add template-settings schema compatibility checks and warnings: introduce `TemplateSettingsWarning` and `checkTemplateSettingsSchemaCompatibility` in `packages/skaff-lib/src/core/plugins/*`, log warnings during plugin loading in the loader, and propagate warnings into CLI (`apps/cli/src/utils/plugin-manager.ts`, commands) and Web UI (`apps/web/src/lib/plugins/*`, components).
- Update greeter examples to emit a normal template key (`greeter_message`) from CLI/web stages, add `greeter_message` to the test-template `templateSettingsSchema`, and refresh greeter docs and type helper README samples to reflect the new approach.

### Testing

- Ran the full library test suite with `bun run test:skaff-lib`; result: all test suites passed (30 suites, 207 tests).
- Ran package-local tests with `cd packages/skaff-lib && bun run test`; result: passed.
- Executed CI-style build/test flow used by the repo's scripts as part of `test:skaff-lib`; result: completed successfully.
- Verified changes via example plugin demos and observed warnings logged for incompatible template/ plugin schemas where applicable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695993f93d688325b92d5b297930106f)