### PR TITLE
Improve web plugin registry setup for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,11 @@ bun --filter apps/web dev
 
 Open http://localhost:3000 to access the interface. When running locally the app uses your home directory’s `~/.config/skaff` by default, and you can update the settings through the UI.
 
+The Web UI build automatically generates an empty plugin registry when no web
+plugins are installed, so a fresh checkout can start without extra setup. To add
+plugins later, set `SKAFF_PLUGINS` and rebuild (`bun --filter apps/web build`) or
+run `bun --filter apps/web generate:plugins`.
+
 ## Contributing
 
 We appreciate contributions of all kinds. Please see the

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,11 +4,11 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "next dev --webpack --port 3000",
+    "dev": "bun run generate:plugins && next dev --webpack --port 3000",
     "build": "bun run generate:plugins && next build --webpack",
     "start": "next start",
-    "lint": "next lint --max-warnings 0",
-    "check-types": "tsc --noEmit",
+    "lint": "bun run generate:plugins && next lint --max-warnings 0",
+    "check-types": "bun run generate:plugins && tsc --noEmit",
     "generate:plugins": "bun run scripts/generate-plugin-registry.ts"
   },
   "dependencies": {


### PR DESCRIPTION
### Motivation
- Fresh checkouts should be able to run the Web UI without requiring any installed web plugins or checked-in generated files.
- Ensure the web plugin registry is always (re)generated before interactive or verification tasks so new contributors have a smooth get‑started experience.
- Document the zero‑plugin local workflow and how to add/regenerate plugins for clarity.

### Description
- Updated `apps/web/package.json` scripts to run `generate:plugins` automatically before `dev`, `lint`, and `check-types` by prefixing those scripts with `bun run generate:plugins`.
- Added README guidance that an empty plugin registry will be generated when no plugins are installed and instructions to add plugins via `SKAFF_PLUGINS` or run `bun --filter apps/web generate:plugins`.
- Left the existing generator script unchanged; this change simply ensures it is invoked by common developer commands.

### Testing
- Ran `bun install` to ensure dependencies install correctly (succeeded).
- Ran `bun run test:skaff-lib` which invoked the library build and tests but failed with TypeScript errors referencing missing/changed exports in `@timonteutelink/template-types-lib` (failed).
- Attempted library test invocation `cd packages/skaff-lib && bun run test` which surfaced the same TypeScript export mismatches (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959b59356b883258d77c9a843611d14)