### PR TITLE
Expand Handlebars validation coverage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -383,7 +383,7 @@
 
     "@babel/helpers": ["@babel/helpers@7.28.4", "", { "dependencies": { "@babel/template": "^7.27.2", "@babel/types": "^7.28.4" } }, "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w=="],
 
-    "@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
+    "@babel/parser": ["@babel/parser@7.26.10", "", { "dependencies": { "@babel/types": "^7.26.10" }, "bin": "./bin/babel-parser.js" }, "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA=="],
 
     "@babel/plugin-syntax-async-generators": ["@babel/plugin-syntax-async-generators@7.8.4", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw=="],
 
@@ -437,9 +437,9 @@
 
     "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
 
-    "@emnapi/core": ["@emnapi/core@1.8.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-ryJnSmj4UhrGLZZPJ6PKVb4wNPAIkW6iyLy+0TRwazd3L1u0wzMe8RfqevAh2HbcSkoeLiSYnOVDOys4JSGYyg=="],
+    "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.8.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Z82FDl1ByxqPEPrAYYeTQVlx2FSHPe1qwX465c+96IRS3fTdSYRoJcRxg3g2fEG5I69z1dSEWQlNRRr0/677mg=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
 
@@ -1551,7 +1551,7 @@
 
     "eslint-compat-utils": ["eslint-compat-utils@0.5.1", "", { "dependencies": { "semver": "^7.5.4" }, "peerDependencies": { "eslint": ">=6.0.0" } }, "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q=="],
 
-    "eslint-config-oclif": ["eslint-config-oclif@6.0.128", "", { "dependencies": { "@eslint/compat": "^1.4.1", "@eslint/eslintrc": "^3.3.3", "@eslint/js": "^9.38.0", "@stylistic/eslint-plugin": "^3.1.0", "@typescript-eslint/eslint-plugin": "^8", "@typescript-eslint/parser": "^8", "eslint-config-oclif": "^5.2.2", "eslint-config-xo": "^0.49.0", "eslint-config-xo-space": "^0.35.0", "eslint-import-resolver-typescript": "^3.10.1", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsdoc": "^50.8.0", "eslint-plugin-mocha": "^10.5.0", "eslint-plugin-n": "^17.22.0", "eslint-plugin-perfectionist": "^4", "eslint-plugin-unicorn": "^56.0.1", "typescript-eslint": "^8.50.1" } }, "sha512-ktbct5MAQMSEe2Jxqz0f4CdsDAVcLU1K5B9I1Vm4FfMiJhVxDtiqrm/6cByIFq9n1xoLgkoIiV25Rlbj+7u13w=="],
+    "eslint-config-oclif": ["eslint-config-oclif@6.0.129", "", { "dependencies": { "@eslint/compat": "^1.4.1", "@eslint/eslintrc": "^3.3.3", "@eslint/js": "^9.38.0", "@stylistic/eslint-plugin": "^3.1.0", "@typescript-eslint/eslint-plugin": "^8", "@typescript-eslint/parser": "^8", "eslint-config-oclif": "^5.2.2", "eslint-config-xo": "^0.49.0", "eslint-config-xo-space": "^0.35.0", "eslint-import-resolver-typescript": "^3.10.1", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsdoc": "^50.8.0", "eslint-plugin-mocha": "^10.5.0", "eslint-plugin-n": "^17.22.0", "eslint-plugin-perfectionist": "^4", "eslint-plugin-unicorn": "^56.0.1", "typescript-eslint": "^8.51.0" } }, "sha512-gUL41BzraulUoPPy8pohJo2brIPG2YsLEF14ZJ/zuGw9m2t1/hs9173ThfcSDL85++B8d0xYwy3gYB3LCo1f6g=="],
 
     "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
 
@@ -2133,7 +2133,7 @@
 
     "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
 
-    "oclif": ["oclif@4.22.61", "", { "dependencies": { "@aws-sdk/client-cloudfront": "^3.958.0", "@aws-sdk/client-s3": "^3.958.0", "@inquirer/confirm": "^3.1.22", "@inquirer/input": "^2.2.4", "@inquirer/select": "^2.5.0", "@oclif/core": "^4.8.0", "@oclif/plugin-help": "^6.2.36", "@oclif/plugin-not-found": "^3.2.73", "@oclif/plugin-warn-if-update-available": "^3.1.53", "ansis": "^3.16.0", "async-retry": "^1.3.3", "change-case": "^4", "debug": "^4.4.0", "ejs": "^3.1.10", "find-yarn-workspace-root": "^2.0.0", "fs-extra": "^8.1", "github-slugger": "^2", "got": "^13", "lodash": "^4.17.21", "normalize-package-data": "^6", "semver": "^7.7.3", "sort-package-json": "^2.15.1", "tiny-jsonc": "^1.0.2", "validate-npm-package-name": "^5.0.1" }, "bin": { "oclif": "bin/run.js" } }, "sha512-fxjZTwg+4NLk6rshf7aI2J8W8Vl/MUePxzOHv3GEhmHlZgXfDD7dswWJ/Dqm/dRk+9oNu7PWH/h48r//RzALuQ=="],
+    "oclif": ["oclif@4.22.63", "", { "dependencies": { "@aws-sdk/client-cloudfront": "^3.962.0", "@aws-sdk/client-s3": "^3.962.0", "@inquirer/confirm": "^3.1.22", "@inquirer/input": "^2.2.4", "@inquirer/select": "^2.5.0", "@oclif/core": "^4.8.0", "@oclif/plugin-help": "^6.2.36", "@oclif/plugin-not-found": "^3.2.73", "@oclif/plugin-warn-if-update-available": "^3.1.53", "ansis": "^3.16.0", "async-retry": "^1.3.3", "change-case": "^4", "debug": "^4.4.0", "ejs": "^3.1.10", "find-yarn-workspace-root": "^2.0.0", "fs-extra": "^8.1", "github-slugger": "^2", "got": "^13", "lodash": "^4.17.21", "normalize-package-data": "^6", "semver": "^7.7.3", "sort-package-json": "^2.15.1", "tiny-jsonc": "^1.0.2", "validate-npm-package-name": "^5.0.1" }, "bin": { "oclif": "bin/run.js" } }, "sha512-xhlXnMLlvnV376ofTKVW9KZk0lsvMSnLqUk6rJ3V18lzMj8grt3s4opWuEib9xgyig0rELCK46iYeZUgw04ibg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -2249,7 +2249,7 @@
 
     "react-dropzone": ["react-dropzone@14.3.8", "", { "dependencies": { "attr-accept": "^2.2.4", "file-selector": "^2.1.0", "prop-types": "^15.8.1" }, "peerDependencies": { "react": ">= 16.8 || 18.0.0" } }, "sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug=="],
 
-    "react-hook-form": ["react-hook-form@7.69.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-yt6ZGME9f4F6WHwevrvpAjh42HMvocuSnSIHUGycBqXIJdhqGSPQzTpGF+1NLREk/58IdPxEMfPcFCjlMhclGw=="],
+    "react-hook-form": ["react-hook-form@7.70.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-COOMajS4FI3Wuwrs3GPpi/Jeef/5W1DRR84Yl5/ShlT3dKVFUfoGiEZ/QE6Uw8P4T2/CLJdcTVYKvWBMQTEpvw=="],
 
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
@@ -2617,7 +2617,7 @@
 
     "yoga-wasm-web": ["yoga-wasm-web@0.3.3", "", {}, "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA=="],
 
-    "zod": ["zod@4.3.4", "", {}, "sha512-Zw/uYiiyF6pUT1qmKbZziChgNPRu+ZRneAsMUDU6IwmXdWt5JwcUfy2bvLOCUtz5UniaN/Zx5aFttZYbYc7O/A=="],
+    "zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
@@ -2631,11 +2631,15 @@
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
+    "@babel/core/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
+
     "@babel/core/@babel/traverse": ["@babel/traverse@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "debug": "^4.3.1" } }, "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ=="],
 
     "@babel/core/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/generator/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
 
     "@babel/generator/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
@@ -2655,13 +2659,15 @@
 
     "@babel/parser/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
+    "@babel/template/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
+
     "@babel/template/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "@babel/traverse/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
 
     "@babel/traverse/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
     "@babel/traverse/globals": ["globals@11.12.0", "", {}, "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="],
-
-    "@endo/module-source/@babel/parser": ["@babel/parser@7.26.10", "", { "dependencies": { "@babel/types": "^7.26.10" }, "bin": "./bin/babel-parser.js" }, "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -2759,9 +2765,9 @@
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-ryJnSmj4UhrGLZZPJ6PKVb4wNPAIkW6iyLy+0TRwazd3L1u0wzMe8RfqevAh2HbcSkoeLiSYnOVDOys4JSGYyg=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-Z82FDl1ByxqPEPrAYYeTQVlx2FSHPe1qwX465c+96IRS3fTdSYRoJcRxg3g2fEG5I69z1dSEWQlNRRr0/677mg=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
 
@@ -2773,9 +2779,13 @@
 
     "@timonteutelink/skaff-plugin-greeter-cli/@inquirer/prompts": ["@inquirer/prompts@5.5.0", "", { "dependencies": { "@inquirer/checkbox": "^2.5.0", "@inquirer/confirm": "^3.2.0", "@inquirer/editor": "^2.2.0", "@inquirer/expand": "^2.3.0", "@inquirer/input": "^2.3.0", "@inquirer/number": "^1.1.0", "@inquirer/password": "^2.2.0", "@inquirer/rawlist": "^2.3.0", "@inquirer/search": "^1.1.0", "@inquirer/select": "^2.5.0" } }, "sha512-BHDeL0catgHdcHbSFFUddNzvx/imzJMft+tWDPwTm3hfu8/tApk1HrooNngB2Mb4qY+KaRWF+iZqoVUPeslEog=="],
 
+    "@types/babel__core/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
+
     "@types/babel__core/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
     "@types/babel__generator/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "@types/babel__template/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
 
     "@types/babel__template/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
@@ -2878,6 +2888,8 @@
     "ink/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "ink/widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
+
+    "istanbul-lib-instrument/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
 
     "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -3327,9 +3339,11 @@
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
-    "@babel/helper-module-transforms/@babel/traverse/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+    "@babel/helper-module-imports/@babel/traverse/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
 
-    "@endo/module-source/@babel/parser/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+    "@babel/helper-module-transforms/@babel/traverse/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
+
+    "@babel/helper-module-transforms/@babel/traverse/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
     "@eslint/css/@eslint/plugin-kit/@eslint/core": ["@eslint/core@0.15.2", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg=="],
 
@@ -3444,6 +3458,8 @@
     "ink/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "ink/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "istanbul-lib-instrument/@babel/parser/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
     "jest-config/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 

--- a/packages/skaff-lib/src/core/templates/TemplateValidation.ts
+++ b/packages/skaff-lib/src/core/templates/TemplateValidation.ts
@@ -22,6 +22,44 @@ export class InvalidTemplateSpecVersionError extends Error {
   }
 }
 
+export class TemplateResourceValidationError extends Error {
+  public readonly templateName: string;
+  public readonly missingPartials: string[];
+  public readonly missingHelpers: string[];
+  public readonly missingSettings: string[];
+
+  constructor(args: {
+    templateName: string;
+    missingPartials: string[];
+    missingHelpers: string[];
+    missingSettings: string[];
+  }) {
+    const missingMessages = [
+      args.missingPartials.length > 0
+        ? `partials: ${args.missingPartials.join(", ")}`
+        : null,
+      args.missingHelpers.length > 0
+        ? `helpers: ${args.missingHelpers.join(", ")}`
+        : null,
+      args.missingSettings.length > 0
+        ? `settings: ${args.missingSettings.join(", ")}`
+        : null,
+    ].filter(Boolean);
+
+    const messageSuffix =
+      missingMessages.length > 0
+        ? `Missing ${missingMessages.join("; ")}`
+        : "Missing required template resources.";
+
+    super(`Template ${args.templateName} validation failed. ${messageSuffix}`);
+    this.name = "TemplateResourceValidationError";
+    this.templateName = args.templateName;
+    this.missingPartials = args.missingPartials;
+    this.missingHelpers = args.missingHelpers;
+    this.missingSettings = args.missingSettings;
+  }
+}
+
 export function validateTemplateSpecVersion(
   templateName: string,
   specVersion: string,
@@ -35,8 +73,21 @@ export function validateTemplateSpecVersion(
 
 export async function validateTemplateResources(template: Template): Promise<void> {
   try {
-    await checkMissingSettings(template);
-    await checkMissingPartials(template);
+    const settingsCheck = await checkMissingSettings(template);
+    const partialsCheck = await checkMissingPartials(template);
+
+    if (
+      settingsCheck.missingSettings.length > 0 ||
+      settingsCheck.missingHelpers.length > 0 ||
+      partialsCheck.missingPartials.length > 0
+    ) {
+      throw new TemplateResourceValidationError({
+        templateName: template.config.templateConfig.name,
+        missingPartials: partialsCheck.missingPartials,
+        missingHelpers: settingsCheck.missingHelpers,
+        missingSettings: settingsCheck.missingSettings,
+      });
+    }
   } catch (error) {
     logError({
       error,

--- a/packages/skaff-lib/src/utils/handlebars-utils.ts
+++ b/packages/skaff-lib/src/utils/handlebars-utils.ts
@@ -1,21 +1,450 @@
+import Handlebars from "handlebars";
+import { glob } from "glob";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import z from "zod";
 import { Template } from "../models/template";
 
+type HandlebarsAstNode = {
+  type: string;
+  [key: string]: unknown;
+};
 
-export async function checkMissingSettings(template: Template) {
-  const helpers = template.config.handlebarHelpers;
+type HandlebarsPathExpression = {
+  type: "PathExpression";
+  parts: string[];
+  original: string;
+  data?: boolean;
+  this?: boolean;
+  depth?: number;
+};
 
+type HandlebarsHash = {
+  pairs: { value: HandlebarsAstNode }[];
+};
 
+type HandlebarsUsage = {
+  partials: Set<string>;
+  helpers: Set<string>;
+  settings: Set<string>;
+};
 
+type TraversalContext = {
+  inScopedContext: number;
+};
+
+const BUILTIN_HELPERS = new Set([
+  "if",
+  "unless",
+  "each",
+  "with",
+  "log",
+  "lookup",
+  "helperMissing",
+  "blockHelperMissing",
+  "*inline",
+]);
+
+const DEFAULT_HELPERS = new Set(["eq", "snakeCase"]);
+const CONTEXT_CHANGING_HELPERS = new Set(["each", "with"]);
+
+function isBinaryContent(buffer: Buffer): boolean {
+  const length = Math.min(buffer.length, 512);
+  let suspicious = 0;
+
+  for (let i = 0; i < length; i++) {
+    const byte = buffer[i]!;
+    if (byte === 0) {
+      return true;
+    }
+
+    if (byte < 7 || (byte > 13 && byte < 32) || byte === 127) {
+      suspicious++;
+      if (suspicious / length > 0.1) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
-export async function checkMissingPartials(template: Template) {
+function collectFromPathExpression(
+  pathExpression: HandlebarsPathExpression,
+  usage: HandlebarsUsage,
+  context: TraversalContext,
+  allowHelper: boolean,
+): void {
+  if (pathExpression.data || pathExpression.this) {
+    return;
+  }
+
+  if (pathExpression.parts.length === 0) {
+    return;
+  }
+
+  if (allowHelper) {
+    usage.helpers.add(pathExpression.original);
+    return;
+  }
+
+  if (context.inScopedContext > 0 && (pathExpression.depth ?? 0) === 0) {
+    return;
+  }
+
+  usage.settings.add(pathExpression.parts.join("."));
+}
+
+function visitHash(
+  hash: HandlebarsHash | undefined,
+  usage: HandlebarsUsage,
+  context: TraversalContext,
+): void {
+  if (!hash) {
+    return;
+  }
+
+  for (const pair of hash.pairs) {
+    visitNode(pair.value, usage, context);
+  }
+}
+
+function visitNode(
+  node: HandlebarsAstNode,
+  usage: HandlebarsUsage,
+  context: TraversalContext,
+): void {
+  switch (node.type) {
+    case "Program": {
+      const body = node.body as HandlebarsAstNode[] | undefined;
+      if (body) {
+        for (const bodyNode of body) {
+          visitNode(bodyNode, usage, context);
+        }
+      }
+      return;
+    }
+    case "MustacheStatement": {
+      const params = (node.params as HandlebarsAstNode[]) ?? [];
+      const hash = node.hash as HandlebarsHash | undefined;
+      const isHelperCall =
+        params.length > 0 || (hash?.pairs.length ?? 0) > 0;
+      if ((node.path as HandlebarsAstNode)?.type === "PathExpression") {
+        collectFromPathExpression(
+          node.path as HandlebarsPathExpression,
+          usage,
+          context,
+          isHelperCall,
+        );
+      }
+      for (const param of params) {
+        visitNode(param, usage, context);
+      }
+      visitHash(hash, usage, context);
+      return;
+    }
+    case "BlockStatement": {
+      const params = (node.params as HandlebarsAstNode[]) ?? [];
+      const hash = node.hash as HandlebarsHash | undefined;
+      if ((node.path as HandlebarsAstNode)?.type === "PathExpression") {
+        collectFromPathExpression(
+          node.path as HandlebarsPathExpression,
+          usage,
+          context,
+          true,
+        );
+      }
+      for (const param of params) {
+        visitNode(param, usage, context);
+      }
+      visitHash(hash, usage, context);
+
+      const isContextChanging =
+        (node.path as HandlebarsAstNode)?.type === "PathExpression" &&
+        CONTEXT_CHANGING_HELPERS.has(
+          (node.path as HandlebarsPathExpression).original,
+        );
+      const nextContext = {
+        inScopedContext: context.inScopedContext + (isContextChanging ? 1 : 0),
+      };
+      if (node.program) {
+        visitNode(node.program as HandlebarsAstNode, usage, nextContext);
+      }
+      if (node.inverse) {
+        visitNode(node.inverse as HandlebarsAstNode, usage, nextContext);
+      }
+      return;
+    }
+    case "PartialStatement": {
+      const name = node.name as HandlebarsAstNode | undefined;
+      const params = (node.params as HandlebarsAstNode[]) ?? [];
+      const hash = node.hash as HandlebarsHash | undefined;
+      if (name?.type === "PathExpression") {
+        usage.partials.add((name as HandlebarsPathExpression).original);
+      } else if (name?.type === "StringLiteral") {
+        const literal = name as { value?: unknown };
+        if (typeof literal.value === "string") {
+          usage.partials.add(literal.value);
+        }
+      }
+      for (const param of params) {
+        visitNode(param, usage, context);
+      }
+      visitHash(hash, usage, context);
+      return;
+    }
+    case "PartialBlockStatement": {
+      const name = node.name as HandlebarsAstNode | undefined;
+      const params = (node.params as HandlebarsAstNode[]) ?? [];
+      const hash = node.hash as HandlebarsHash | undefined;
+      if (name?.type === "PathExpression") {
+        usage.partials.add((name as HandlebarsPathExpression).original);
+      } else if (name?.type === "StringLiteral") {
+        const literal = name as { value?: unknown };
+        if (typeof literal.value === "string") {
+          usage.partials.add(literal.value);
+        }
+      }
+      for (const param of params) {
+        visitNode(param, usage, context);
+      }
+      visitHash(hash, usage, context);
+      if (node.program) {
+        visitNode(node.program as HandlebarsAstNode, usage, context);
+      }
+      return;
+    }
+    case "SubExpression": {
+      const params = (node.params as HandlebarsAstNode[]) ?? [];
+      const hash = node.hash as HandlebarsHash | undefined;
+      if ((node.path as HandlebarsAstNode)?.type === "PathExpression") {
+        collectFromPathExpression(
+          node.path as HandlebarsPathExpression,
+          usage,
+          context,
+          true,
+        );
+      }
+      for (const param of params) {
+        visitNode(param, usage, context);
+      }
+      visitHash(hash, usage, context);
+      return;
+    }
+    case "PathExpression": {
+      collectFromPathExpression(
+        node as HandlebarsPathExpression,
+        usage,
+        context,
+        false,
+      );
+      return;
+    }
+    default:
+      return;
+  }
+}
+
+function collectHandlebarsUsageFromString(
+  templateSource: string,
+  usage: HandlebarsUsage,
+): void {
+  const ast = Handlebars.parse(templateSource) as unknown as HandlebarsAstNode;
+  visitNode(ast, usage, { inScopedContext: 0 });
+}
+
+async function collectHandlebarsUsage(
+  template: Template,
+): Promise<HandlebarsUsage> {
+  const usage: HandlebarsUsage = {
+    partials: new Set(),
+    helpers: new Set(),
+    settings: new Set(),
+  };
+
+  const entries = await glob("**/*", {
+    cwd: template.absoluteFilesDir,
+    dot: true,
+    nodir: true,
+  });
+
+  for (const entry of entries) {
+    const fileBuffer = await readFile(
+      path.join(template.absoluteFilesDir, entry),
+    );
+    const shouldTemplate = entry.endsWith(".hbs") || !isBinaryContent(fileBuffer);
+    if (!shouldTemplate) {
+      continue;
+    }
+    collectHandlebarsUsageFromString(fileBuffer.toString("utf-8"), usage);
+  }
+
+  const partials = await template.findAllPartials();
+  if ("error" in partials) {
+    throw new Error(partials.error);
+  }
+
+  for (const partialPath of Object.values(partials.data)) {
+    const partialBuffer = await readFile(partialPath);
+    collectHandlebarsUsageFromString(partialBuffer.toString("utf-8"), usage);
+  }
+
+  return usage;
+}
+
+type ZodSchema = z.ZodType;
+type ZodSchemaDef = {
+  type: string;
+  innerType?: ZodSchema;
+  shape?: Record<string, ZodSchema>;
+  element?: ZodSchema;
+  items?: ZodSchema[];
+  options?: ZodSchema[];
+  left?: ZodSchema;
+  right?: ZodSchema;
+  out?: ZodSchema;
+  rest?: ZodSchema | null;
+  valueType?: ZodSchema;
+};
+
+function unwrapSchema(schema: ZodSchema): ZodSchema {
+  let current: ZodSchema = schema;
+  while (true) {
+    const def = current.def as ZodSchemaDef;
+    switch (def.type) {
+      case "optional":
+      case "default":
+      case "nullable":
+      case "catch":
+      case "prefault":
+      case "readonly":
+      case "nonoptional":
+        if (!def.innerType) {
+          return current;
+        }
+        current = def.innerType;
+        continue;
+      case "pipe":
+        if (!def.out) {
+          return current;
+        }
+        current = def.out;
+        continue;
+      default:
+        return current;
+    }
+  }
+}
+
+function isNumericPart(part: string): boolean {
+  return part !== "" && Number.isFinite(Number(part));
+}
+
+function hasSchemaPath(
+  schema: ZodSchema,
+  parts: string[],
+): boolean {
+  if (parts.length === 0) {
+    return true;
+  }
+
+  const current = unwrapSchema(schema);
+  const def = current.def as ZodSchemaDef;
+
+  if (def.type === "object" && def.shape) {
+    const [head, ...rest] = parts;
+    if (!head) {
+      return false;
+    }
+    const nextSchema = def.shape[head];
+    if (!nextSchema) {
+      return false;
+    }
+    return hasSchemaPath(nextSchema, rest);
+  }
+
+  if (def.type === "array" && def.element) {
+    const [head, ...rest] = parts;
+    const remaining = head && isNumericPart(head) ? rest : parts;
+    return hasSchemaPath(def.element, remaining);
+  }
+
+  if (def.type === "tuple" && def.items) {
+    const [head, ...rest] = parts;
+    if (!head || !isNumericPart(head)) {
+      return false;
+    }
+    const index = Number(head);
+    const item = def.items[index];
+    if (!item) {
+      return false;
+    }
+    return hasSchemaPath(item, rest);
+  }
+
+  if (def.type === "record" && def.valueType) {
+    const [, ...rest] = parts;
+    if (rest.length === 0) {
+      return true;
+    }
+    return hasSchemaPath(def.valueType, rest);
+  }
+
+  if (def.type === "union" && def.options) {
+    return def.options.some((option) => hasSchemaPath(option, parts));
+  }
+
+  if (def.type === "intersection" && def.left && def.right) {
+    return hasSchemaPath(def.left, parts) || hasSchemaPath(def.right, parts);
+  }
+
+  return false;
+}
+
+export async function checkMissingSettings(
+  template: Template,
+): Promise<{ missingSettings: string[]; missingHelpers: string[] }> {
+  const usage = await collectHandlebarsUsage(template);
+  const helpers = template.config.handlebarHelpers ?? {};
+
+  const availableHelpers = new Set<string>([
+    ...BUILTIN_HELPERS,
+    ...DEFAULT_HELPERS,
+    ...Object.keys(helpers),
+  ]);
+
+  const missingHelpers = Array.from(usage.helpers).filter(
+    (helper) => !availableHelpers.has(helper),
+  );
+
+  const schema =
+    template.config.templateFinalSettingsSchema ??
+    template.config.templateSettingsSchema;
+  const missingSettings = Array.from(usage.settings).filter((settingPath) => {
+    const parts = settingPath.split(".").filter(Boolean);
+    return !hasSchemaPath(schema as ZodSchema, parts);
+  });
+
+  return {
+    missingSettings: missingSettings.sort(),
+    missingHelpers: missingHelpers.sort(),
+  };
+}
+
+export async function checkMissingPartials(
+  template: Template,
+): Promise<{ missingPartials: string[] }> {
+  const usage = await collectHandlebarsUsage(template);
   const partials = await template.findAllPartials();
 
   if ("error" in partials) {
     throw new Error(partials.error);
   }
 
-  //TODO: Check handlebars if every used partial exists. Every helper exists and every final setting is in zod.
+  const availablePartials = new Set(Object.keys(partials.data));
+  const missingPartials = Array.from(usage.partials).filter(
+    (partial) => !availablePartials.has(partial),
+  );
 
-
+  return { missingPartials: missingPartials.sort() };
 }

--- a/packages/skaff-lib/tests/handlebars-utils.test.ts
+++ b/packages/skaff-lib/tests/handlebars-utils.test.ts
@@ -1,0 +1,223 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, jest } from "@jest/globals";
+import type { HelperDelegate } from "handlebars";
+import { z } from "zod";
+
+import { Template } from "../src/core/templates/Template";
+import { validateTemplateResources } from "../src/core/templates/TemplateValidation";
+import type { GenericTemplateConfigModule } from "../src/lib/types";
+
+jest.mock("../src/lib/logger", () => ({
+  backendLogger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    trace: jest.fn(),
+  },
+}));
+
+type TemplateFixture = {
+  template: Template;
+  cleanup: () => Promise<void>;
+};
+
+async function createTemplateFixture(options: {
+  fileContents?: string;
+  files?: Record<string, string>;
+  schema: z.ZodType;
+  partials?: Record<string, string>;
+  handlebarHelpers?: Record<string, HelperDelegate>;
+}): Promise<TemplateFixture> {
+  const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "skaff-hbs-"));
+  const templateDir = path.join(baseDir, "template");
+  const filesDir = path.join(templateDir, "files");
+  await fs.mkdir(filesDir, { recursive: true });
+  const files =
+    options.files ??
+    (options.fileContents
+      ? { "template.txt": options.fileContents }
+      : undefined);
+  if (files) {
+    for (const [name, contents] of Object.entries(files)) {
+      await fs.writeFile(path.join(filesDir, name), contents, "utf8");
+    }
+  }
+
+  let partialsDir: string | undefined;
+  if (options.partials) {
+    partialsDir = path.join(templateDir, "partials");
+    await fs.mkdir(partialsDir, { recursive: true });
+    for (const [name, contents] of Object.entries(options.partials)) {
+      await fs.writeFile(path.join(partialsDir, `${name}.hbs`), contents, "utf8");
+    }
+  }
+
+  const templateConfig: GenericTemplateConfigModule = {
+    templateConfig: {
+      name: "validation-template",
+      author: "Test",
+      specVersion: "0.0.1",
+    },
+    templateSettingsSchema: options.schema,
+    templateFinalSettingsSchema: options.schema,
+    mapFinalSettings: ({ templateSettings }) => templateSettings,
+    handlebarHelpers: options.handlebarHelpers,
+  } as GenericTemplateConfigModule;
+
+  const template = new Template({
+    config: templateConfig,
+    absoluteBaseDir: baseDir,
+    absoluteDir: templateDir,
+    absoluteFilesDir: filesDir,
+    partialsDir,
+  });
+
+  return {
+    template,
+    cleanup: () => fs.rm(baseDir, { recursive: true, force: true }),
+  };
+}
+
+describe("handlebars template validation", () => {
+  it("reports missing partials", async () => {
+    const fixture = await createTemplateFixture({
+      fileContents: "Hello {{> missing_partial}}",
+      schema: z.object({ message: z.string().default("hi") }),
+    });
+
+    try {
+      await expect(validateTemplateResources(fixture.template)).rejects.toMatchObject({
+        name: "TemplateResourceValidationError",
+        templateName: "validation-template",
+        missingPartials: ["missing_partial"],
+      });
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("reports missing settings", async () => {
+    const fixture = await createTemplateFixture({
+      fileContents: "Hello {{missing_setting}}",
+      schema: z.object({ message: z.string().default("hi") }),
+    });
+
+    try {
+      await expect(validateTemplateResources(fixture.template)).rejects.toMatchObject({
+        name: "TemplateResourceValidationError",
+        templateName: "validation-template",
+        missingSettings: ["missing_setting"],
+      });
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("reports missing helpers", async () => {
+    const fixture = await createTemplateFixture({
+      fileContents: "Hello {{missingHelper message}}",
+      schema: z.object({ message: z.string().default("hi") }),
+    });
+
+    try {
+      await expect(validateTemplateResources(fixture.template)).rejects.toMatchObject({
+        name: "TemplateResourceValidationError",
+        templateName: "validation-template",
+        missingHelpers: ["missingHelper"],
+      });
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("allows built-in and default helpers", async () => {
+    const fixture = await createTemplateFixture({
+      fileContents:
+        "{{#if enabled}}{{snakeCase message}}{{/if}}{{#unless disabled}}{{eq message \"hi\"}}{{/unless}}",
+      schema: z.object({
+        enabled: z.boolean().default(true),
+        disabled: z.boolean().default(false),
+        message: z.string().default("hi"),
+      }),
+    });
+
+    try {
+      await expect(validateTemplateResources(fixture.template)).resolves.toBeUndefined();
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("allows helpers defined on the template", async () => {
+    const fixture = await createTemplateFixture({
+      fileContents: "Hello {{shout message}}",
+      schema: z.object({ message: z.string().default("hi") }),
+      handlebarHelpers: {
+        shout: (value: string) => value.toUpperCase(),
+      },
+    });
+
+    try {
+      await expect(validateTemplateResources(fixture.template)).resolves.toBeUndefined();
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("detects missing settings referenced in partials", async () => {
+    const fixture = await createTemplateFixture({
+      fileContents: "Hello {{> shared}}",
+      schema: z.object({ message: z.string().default("hi") }),
+      partials: {
+        shared: "Partial says {{missing_setting}}",
+      },
+    });
+
+    try {
+      await expect(validateTemplateResources(fixture.template)).rejects.toMatchObject({
+        name: "TemplateResourceValidationError",
+        missingSettings: ["missing_setting"],
+      });
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("supports nested settings paths and array indices", async () => {
+    const fixture = await createTemplateFixture({
+      fileContents: "First item: {{items.0.label}}",
+      schema: z.object({
+        items: z.array(z.object({ label: z.string() })).default([{ label: "one" }]),
+      }),
+    });
+
+    try {
+      await expect(validateTemplateResources(fixture.template)).resolves.toBeUndefined();
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("detects missing helpers in subexpressions", async () => {
+    const fixture = await createTemplateFixture({
+      fileContents: "Hello {{uppercase (missingSubHelper message)}}",
+      schema: z.object({ message: z.string().default("hi") }),
+      handlebarHelpers: {
+        uppercase: (value: string) => value.toUpperCase(),
+      },
+    });
+
+    try {
+      await expect(validateTemplateResources(fixture.template)).rejects.toMatchObject({
+        name: "TemplateResourceValidationError",
+        missingHelpers: ["missingSubHelper"],
+      });
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
### Motivation
- Surface missing Handlebars resources (partials, helpers, and referenced settings) before template generation to catch authoring errors early.
- Provide a structured error type that includes the template name and lists of missing items for clearer diagnostics.
- Improve template validation coverage by adding tests for built-in helpers, custom helpers, partial-contained references, nested paths and subexpressions.

### Description
- Implemented Handlebars AST usage collection and traversal in `packages/skaff-lib/src/utils/handlebars-utils.ts` and added `collectHandlebarsUsage`, `checkMissingSettings`, and `checkMissingPartials` helpers.
- Added `TemplateResourceValidationError` and updated `validateTemplateResources` in `packages/skaff-lib/src/core/templates/TemplateValidation.ts` to throw structured validation errors containing `missingPartials`, `missingHelpers`, and `missingSettings`.
- Expanded the unit test suite at `packages/skaff-lib/tests/handlebars-utils.test.ts` to cover built-in and default helpers, template-defined helpers, partials that reference settings, nested/array paths, and subexpression helper detection.
- Updated project lockfile by running dependency install so tests run against the current dependency set (`bun.lock`).

### Testing
- Ran `make cr` to clean install artifacts and then `bun install`, which completed but reported `bun2nix` missing and that 2 postinstalls were blocked; installation still completed successfully.
- Built the types library with `cd packages/template-types-lib && bun run build` and then executed the package tests with `cd packages/skaff-lib && bun run test`.
- During the first test run a Handlebars parse error from a subexpression test was observed and the test was adjusted to include a wrapper helper; after that change the full test run succeeded.
- All automated tests passed: `Test Suites: 31 passed` and `Tests: 215 passed` (final run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959c9f218d08325a786faa2e23a9069)