### PR TITLE
Unify plugin settings compatibility validation

### DIFF
--- a/apps/cli/src/utils/plugin-manager.ts
+++ b/apps/cli/src/utils/plugin-manager.ts
@@ -14,6 +14,7 @@ import * as skaffLib from '@timonteutelink/skaff-lib'
 import type {
   InstalledPluginInfo,
   PluginTrustLevel,
+  SkaffPluginModule,
   SinglePluginCompatibilityResult,
   TemplateSettingsWarning,
   TemplatePluginCompatibilityResult,
@@ -365,110 +366,41 @@ export async function checkTemplatePluginsCompatibility(
   templateSettingsSchema?: z.ZodObject<UserTemplateSettings>,
 ): Promise<TemplatePluginCompatibilityResult> {
   const installedMap = await buildInstalledPluginsMap(config)
-  const baseResult = skaffLib.checkTemplatePluginCompatibility(templatePlugins, installedMap)
   const normalized = skaffLib.normalizeTemplatePlugins(templatePlugins)
 
   if (!normalized.length) {
-    return baseResult
+    return skaffLib.checkTemplatePluginCompatibility(templatePlugins, installedMap)
   }
 
   const pluginSettings = await skaffLib.getAllPluginSystemSettings()
-  const updatedEntries = await Promise.all(
-    baseResult.plugins.map(async (pluginResult) => {
-      if (!pluginResult.compatible) {
-        return {pluginResult}
-      }
+  const pluginModuleResults = new Map<string, skaffLib.Result<SkaffPluginModule>>()
 
-      const pluginConfig = normalized.find((entry) => entry.module === pluginResult.module)
-      if (!pluginConfig) {
-        return {pluginResult}
-      }
-
+  await Promise.all(
+    normalized.map(async (pluginConfig) => {
       const moduleResult = await skaffLib.resolveRegisteredPluginModule(pluginConfig)
-      if ('error' in moduleResult) {
-        return {
-          pluginResult: {
-            ...pluginResult,
-            compatible: false,
-            reason: 'invalid_global_config' as const,
-            message: `Unable to load plugin for global settings validation: ${moduleResult.error}`,
-          },
-        }
-      }
-
-      const pluginModule = moduleResult.data
-      const pluginName = pluginModule.manifest?.name ?? skaffLib.extractPluginName(pluginConfig.module)
-      let updatedPluginResult = pluginResult
-      if (pluginModule.globalConfigSchema) {
-        const rawSettings = pluginSettings[pluginName]
-        const parsed = pluginModule.globalConfigSchema.safeParse(rawSettings ?? {})
-
-        if (!parsed.success) {
-          updatedPluginResult = {
-            ...pluginResult,
-            compatible: false,
-            reason: 'invalid_global_config' as const,
-            message: `Invalid global config for plugin ${pluginName}: ${parsed.error}`,
-          }
-        }
-      }
-
-      let warning: TemplateSettingsWarning | undefined
-      if (templateSettingsSchema && pluginModule.requiredTemplateSettingsSchema) {
-        const compatibility = skaffLib.checkTemplateSettingsSchemaCompatibility(
-          templateSettingsSchema,
-          pluginModule.requiredTemplateSettingsSchema,
-        )
-        if (!compatibility.compatible) {
-          warning = {
-            module: pluginConfig.module,
-            missingKeys: compatibility.missingKeys,
-            optionalKeys: compatibility.optionalKeys,
-            message: skaffLib.formatTemplateSettingsSchemaWarning(pluginName, compatibility),
-          }
-        }
-      }
-
-      return {pluginResult: updatedPluginResult, warning}
+      pluginModuleResults.set(pluginConfig.module, moduleResult)
     }),
   )
 
-  const missing: SinglePluginCompatibilityResult[] = []
-  const versionMismatches: SinglePluginCompatibilityResult[] = []
-  const invalidGlobalConfig: SinglePluginCompatibilityResult[] = []
-  const compatible: SinglePluginCompatibilityResult[] = []
-  const templateSettingsWarnings: TemplateSettingsWarning[] = []
+  const {validateGlobalConfig, validateTemplateSettings} = skaffLib.createPluginCompatibilityValidators({
+    pluginSettings,
+    templateSettingsSchema,
+    resolvePluginModule: (pluginConfig) => {
+      const moduleResult = pluginModuleResults.get(pluginConfig.module)
+      if (moduleResult) {
+        return moduleResult
+      }
+      return {
+        error: `Plugin ${pluginConfig.module} could not be resolved for settings validation`,
+      }
+    },
+    includeTemplateSettingsLoadErrors: false,
+  })
 
-  const updatedPlugins = updatedEntries.map((entry) => entry.pluginResult)
-
-  for (const entry of updatedEntries) {
-    if (entry.warning) {
-      templateSettingsWarnings.push(entry.warning)
-    }
-
-    const result = entry.pluginResult
-    if (result.compatible) {
-      compatible.push(result)
-    } else if (result.reason === 'not_installed') {
-      missing.push(result)
-    } else if (result.reason === 'invalid_global_config') {
-      invalidGlobalConfig.push(result)
-    } else {
-      versionMismatches.push(result)
-    }
-  }
-
-  return {
-    ...baseResult,
-    plugins: updatedPlugins,
-    missing,
-    versionMismatches,
-    invalidGlobalConfig,
-    compatible,
-    allCompatible:
-      missing.length === 0 && versionMismatches.length === 0 && invalidGlobalConfig.length === 0,
-    templateSettingsWarnings,
-  }
+  return skaffLib.checkTemplatePluginCompatibility(templatePlugins, installedMap, {
+    validateGlobalConfig,
+    validateTemplateSettings,
+  })
 }
 
 /**

--- a/apps/web/src/lib/plugins/web-stage-loader.ts
+++ b/apps/web/src/lib/plugins/web-stage-loader.ts
@@ -12,11 +12,9 @@
 import type {
   SkaffPluginModule,
   PluginStageEntry,
-  TemplatePluginConfig,
   PluginTrustLevel,
   InstalledPluginInfo,
   TemplateSettingsWarning,
-  TemplateSettingsSchemaCompatibility,
   TemplatePluginCompatibilityResult,
   SinglePluginCompatibilityResult,
   TemplateDTO,
@@ -31,7 +29,7 @@ import {
   createPluginStageEntry,
   checkTemplatePluginCompatibility,
   extractPluginName,
-  formatTemplateSettingsSchemaWarning,
+  createPluginCompatibilityValidators,
 } from "@timonteutelink/skaff-lib/browser";
 
 import {
@@ -39,7 +37,6 @@ import {
   PLUGIN_MANIFEST,
   type PluginManifestEntry,
 } from "./generated-plugin-registry";
-import { z } from "zod";
 
 /**
  * Information about a plugin that is required but not installed.
@@ -165,12 +162,43 @@ export function checkPluginCompatibility(
 
   // Use the skaff-lib compatibility checker with semver support
   const installedPluginsMap = buildInstalledPluginsMap();
+  const { validateGlobalConfig, validateTemplateSettings } =
+    createPluginCompatibilityValidators({
+      pluginSettings,
+      templateSettingsSchema: template.config.templateSettingsSchema,
+      resolvePluginModule: (pluginConfig) => {
+        const pluginName = extractPluginName(pluginConfig.module);
+        const moduleExports = getInstalledPlugin(pluginName);
+        const resolvedModule =
+          moduleExports ?? getInstalledPlugin(pluginConfig.module);
+
+        if (!resolvedModule) {
+          return {
+            error: `Plugin "${pluginName}" is installed but could not be loaded`,
+          };
+        }
+
+        const entry = pickEntrypoint(resolvedModule, pluginConfig.exportName);
+        const pluginModule = coerceToPluginModule(entry);
+        if (!pluginModule) {
+          return {
+            error: `Plugin "${pluginName}" is installed but could not be loaded`,
+          };
+        }
+
+        return { data: pluginModule };
+      },
+      formatModuleLoadError: (pluginName, purpose) => {
+        if (purpose === "template_settings") {
+          return `Plugin "${pluginName}" is installed but could not be loaded for template settings validation`;
+        }
+        return `Plugin "${pluginName}" is installed but could not be loaded for settings validation`;
+      },
+    });
   const result: TemplatePluginCompatibilityResult =
     checkTemplatePluginCompatibility(plugins, installedPluginsMap, {
-      validateGlobalConfig: (pluginConfig) =>
-        validateGlobalPluginSettings(pluginConfig, pluginSettings),
-      validateTemplateSettings: (pluginConfig) =>
-        validateTemplateSettingsSchema(pluginConfig, template),
+      validateGlobalConfig,
+      validateTemplateSettings,
     });
 
   // Convert to the web-specific format
@@ -227,121 +255,6 @@ export function checkPluginCompatibility(
     hasTrustWarnings: untrustedPlugins.length > 0,
     untrustedPlugins,
   };
-}
-
-function validateGlobalPluginSettings(
-  pluginConfig: TemplatePluginConfig,
-  pluginSettings?: Record<string, unknown>,
-): { data: undefined } | { error: string } {
-  const pluginName = extractPluginName(pluginConfig.module);
-  const moduleExports = getInstalledPlugin(pluginName);
-  const resolvedModule = moduleExports ?? getInstalledPlugin(pluginConfig.module);
-
-  if (!resolvedModule) {
-    return {
-      error: `Plugin "${pluginName}" is installed but could not be loaded for settings validation`,
-    };
-  }
-
-  const entry = pickEntrypoint(resolvedModule, pluginConfig.exportName);
-  const pluginModule = coerceToPluginModule(entry);
-  if (!pluginModule?.globalConfigSchema) {
-    return { data: undefined };
-  }
-
-  const manifestName = pluginModule.manifest?.name ?? pluginName;
-  const rawSettings = pluginSettings?.[manifestName];
-  const parsed = pluginModule.globalConfigSchema.safeParse(rawSettings ?? {});
-
-  if (!parsed.success) {
-    return {
-      error: `Invalid global config for plugin ${manifestName}: ${parsed.error}`,
-    };
-  }
-
-  return { data: undefined };
-}
-
-function validateTemplateSettingsSchema(
-  pluginConfig: TemplatePluginConfig,
-  template: TemplateDTO,
-): { data: TemplateSettingsWarning | undefined } | { error: string } {
-  const pluginName = extractPluginName(pluginConfig.module);
-  const moduleExports = getInstalledPlugin(pluginName);
-  const resolvedModule = moduleExports ?? getInstalledPlugin(pluginConfig.module);
-
-  if (!resolvedModule) {
-    return {
-      error: `Plugin "${pluginName}" is installed but could not be loaded for template settings validation`,
-    };
-  }
-
-  const entry = pickEntrypoint(resolvedModule, pluginConfig.exportName);
-  const pluginModule = coerceToPluginModule(entry);
-  const requiredSchema = pluginModule?.requiredTemplateSettingsSchema;
-  if (!requiredSchema) {
-    return { data: undefined };
-  }
-
-  const compatibility = checkTemplateSettingsJsonCompatibility(
-    template.config.templateSettingsSchema,
-    z.toJSONSchema(requiredSchema),
-  );
-
-  if (compatibility.compatible) {
-    return { data: undefined };
-  }
-
-  const manifestName = pluginModule?.manifest?.name ?? pluginName;
-  return {
-    data: {
-      module: pluginConfig.module,
-      missingKeys: compatibility.missingKeys,
-      optionalKeys: compatibility.optionalKeys,
-      message: formatTemplateSettingsSchemaWarning(manifestName, compatibility),
-    },
-  };
-}
-
-function checkTemplateSettingsJsonCompatibility(
-  templateSchema: unknown,
-  requiredSchema: unknown,
-): TemplateSettingsSchemaCompatibility {
-  const templateInfo = getJsonSchemaInfo(templateSchema);
-  const requiredInfo = getJsonSchemaInfo(requiredSchema);
-
-  const missingKeys = [...requiredInfo.properties].filter(
-    (key) => !templateInfo.properties.has(key),
-  );
-  const optionalKeys = [...requiredInfo.required].filter(
-    (key) =>
-      templateInfo.properties.has(key) && !templateInfo.required.has(key),
-  );
-
-  return {
-    compatible: missingKeys.length === 0 && optionalKeys.length === 0,
-    missingKeys,
-    optionalKeys,
-  };
-}
-
-function getJsonSchemaInfo(schema: unknown): {
-  properties: Set<string>;
-  required: Set<string>;
-} {
-  if (!schema || typeof schema !== "object") {
-    return { properties: new Set(), required: new Set() };
-  }
-
-  const schemaRecord = schema as {
-    properties?: Record<string, unknown>;
-    required?: string[];
-  };
-  const properties = new Set(Object.keys(schemaRecord.properties ?? {}));
-  const required = new Set(
-    Array.isArray(schemaRecord.required) ? schemaRecord.required : [],
-  );
-  return { properties, required };
 }
 
 export type WebPluginStageEntry = PluginStageEntry<WebTemplateStage>;

--- a/packages/skaff-lib/src/core/plugins/plugin-compatibility.ts
+++ b/packages/skaff-lib/src/core/plugins/plugin-compatibility.ts
@@ -15,6 +15,7 @@ import {
   normalizeTemplatePlugins,
   type NormalizedTemplatePluginConfig,
 } from "./plugin-types";
+import type { SkaffPluginModule } from "./plugin-types";
 import { parsePackageSpec } from "./package-spec";
 import type { Result } from "../../lib/types";
 
@@ -108,6 +109,17 @@ export interface TemplateSettingsSchemaCompatibility {
   optionalKeys: string[];
 }
 
+export interface JsonSchemaShape {
+  properties?: Record<string, unknown>;
+  required?: string[];
+}
+
+export type TemplateSettingsSchemaInput =
+  | z.ZodTypeAny
+  | JsonSchemaShape
+  | null
+  | undefined;
+
 /**
  * Extracts the plugin name from a module specifier.
  * Handles scoped packages like @scope/plugin-name and version suffixes.
@@ -187,6 +199,32 @@ export function checkTemplateSettingsSchemaCompatibility(
   };
 }
 
+export function checkTemplateSettingsSchemaCompatibilityInput(
+  templateSettingsSchema: TemplateSettingsSchemaInput,
+  requiredTemplateSettingsSchema: TemplateSettingsSchemaInput,
+): TemplateSettingsSchemaCompatibility {
+  const templateInfo = getJsonSchemaInfo(
+    normalizeSchemaInput(templateSettingsSchema),
+  );
+  const requiredInfo = getJsonSchemaInfo(
+    normalizeSchemaInput(requiredTemplateSettingsSchema),
+  );
+
+  const missingKeys = [...requiredInfo.properties].filter(
+    (key) => !templateInfo.properties.has(key),
+  );
+  const optionalKeys = [...requiredInfo.required].filter(
+    (key) =>
+      templateInfo.properties.has(key) && !templateInfo.required.has(key),
+  );
+
+  return {
+    compatible: missingKeys.length === 0 && optionalKeys.length === 0,
+    missingKeys,
+    optionalKeys,
+  };
+}
+
 export function formatTemplateSettingsSchemaWarning(
   pluginName: string,
   compatibility: TemplateSettingsSchemaCompatibility,
@@ -207,6 +245,137 @@ export function formatTemplateSettingsSchemaWarning(
     `Template settings schema does not satisfy required settings for plugin "${pluginName}". ` +
     `${parts.join("; ")}.`
   );
+}
+
+export interface PluginCompatibilityValidatorOptions {
+  pluginSettings?: Record<string, unknown>;
+  templateSettingsSchema?: TemplateSettingsSchemaInput;
+  resolvePluginModule: (
+    pluginConfig: NormalizedTemplatePluginConfig,
+    installedPlugin: InstalledPluginInfo | undefined,
+  ) => Result<SkaffPluginModule>;
+  formatModuleLoadError?: (
+    pluginName: string,
+    purpose: "global_config" | "template_settings",
+    error: string,
+  ) => string;
+  includeTemplateSettingsLoadErrors?: boolean;
+}
+
+export function createPluginCompatibilityValidators(
+  options: PluginCompatibilityValidatorOptions,
+): {
+  validateGlobalConfig: GlobalConfigValidator;
+  validateTemplateSettings: TemplateSettingsValidator;
+} {
+  const formatModuleLoadError =
+    options.formatModuleLoadError ??
+    ((_pluginName, purpose, error) => {
+      if (purpose === "template_settings") {
+        return `Unable to load plugin for template settings validation: ${error}`;
+      }
+      return `Unable to load plugin for global settings validation: ${error}`;
+    });
+  const includeTemplateSettingsLoadErrors =
+    options.includeTemplateSettingsLoadErrors ?? true;
+
+  const resolveModule = (
+    pluginConfig: NormalizedTemplatePluginConfig,
+    installedPlugin: InstalledPluginInfo | undefined,
+  ): Result<SkaffPluginModule> => {
+    return options.resolvePluginModule(pluginConfig, installedPlugin);
+  };
+
+  const validateGlobalConfig: GlobalConfigValidator = (
+    pluginConfig,
+    installedPlugin,
+  ) => {
+    const pluginName = extractPluginName(pluginConfig.module);
+    const moduleResult = resolveModule(pluginConfig, installedPlugin);
+    if ("error" in moduleResult) {
+      return {
+        error: formatModuleLoadError(
+          pluginName,
+          "global_config",
+          moduleResult.error,
+        ),
+      };
+    }
+
+    const pluginModule = moduleResult.data;
+    if (!pluginModule.globalConfigSchema) {
+      return { data: undefined };
+    }
+
+    const manifestName = pluginModule.manifest?.name ?? pluginName;
+    const rawSettings = options.pluginSettings?.[manifestName];
+    const parsed = pluginModule.globalConfigSchema.safeParse(rawSettings ?? {});
+
+    if (!parsed.success) {
+      return {
+        error: `Invalid global config for plugin ${manifestName}: ${parsed.error}`,
+      };
+    }
+
+    return { data: undefined };
+  };
+
+  const validateTemplateSettings: TemplateSettingsValidator = (
+    pluginConfig,
+    installedPlugin,
+  ) => {
+    if (!options.templateSettingsSchema) {
+      return { data: undefined };
+    }
+
+    const pluginName = extractPluginName(pluginConfig.module);
+    const moduleResult = resolveModule(pluginConfig, installedPlugin);
+    if ("error" in moduleResult) {
+      if (!includeTemplateSettingsLoadErrors) {
+        return { data: undefined };
+      }
+      return {
+        error: formatModuleLoadError(
+          pluginName,
+          "template_settings",
+          moduleResult.error,
+        ),
+      };
+    }
+
+    const pluginModule = moduleResult.data;
+    const requiredSchema = pluginModule.requiredTemplateSettingsSchema;
+    if (!requiredSchema) {
+      return { data: undefined };
+    }
+
+    const compatibility = checkTemplateSettingsSchemaCompatibilityInput(
+      options.templateSettingsSchema,
+      requiredSchema,
+    );
+
+    if (compatibility.compatible) {
+      return { data: undefined };
+    }
+
+    const manifestName = pluginModule.manifest?.name ?? pluginName;
+    return {
+      data: {
+        module: pluginConfig.module,
+        missingKeys: compatibility.missingKeys,
+        optionalKeys: compatibility.optionalKeys,
+        message: formatTemplateSettingsSchemaWarning(
+          manifestName,
+          compatibility,
+        ),
+      },
+    };
+  };
+
+  return {
+    validateGlobalConfig,
+    validateTemplateSettings,
+  };
 }
 
 /**
@@ -466,4 +635,46 @@ function findInstalledPluginInfo(
   }
 
   return installedPlugin;
+}
+
+function normalizeSchemaInput(
+  schema: TemplateSettingsSchemaInput,
+): JsonSchemaShape | undefined {
+  if (!schema) {
+    return undefined;
+  }
+
+  if (isZodSchema(schema)) {
+    return z.toJSONSchema(schema);
+  }
+
+  if (typeof schema === "object") {
+    return schema as JsonSchemaShape;
+  }
+
+  return undefined;
+}
+
+function isZodSchema(value: unknown): value is z.ZodTypeAny {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  return (
+    "safeParse" in value &&
+    typeof (value as z.ZodTypeAny).safeParse === "function"
+  );
+}
+
+function getJsonSchemaInfo(
+  schema: JsonSchemaShape | undefined,
+): { properties: Set<string>; required: Set<string> } {
+  if (!schema || typeof schema !== "object") {
+    return { properties: new Set(), required: new Set() };
+  }
+
+  const properties = new Set(Object.keys(schema.properties ?? {}));
+  const required = new Set(
+    Array.isArray(schema.required) ? schema.required : [],
+  );
+  return { properties, required };
 }


### PR DESCRIPTION
### Motivation

- Provide a single shared helper for validating plugin global settings and template settings schema compatibility so CLI and Web use the same logic and messaging.
- Accept either Zod schemas or JSON‑schema shaped inputs for template settings compatibility checks to support both runtime Zod objects and prebuilt JSON schemas.
- Remove duplicated inline validation code paths in Web and CLI to reduce drift and keep warnings consistent.
- Allow the compatibility checks to resolve plugin modules through pluggable resolvers so different environments can provide plugin loading behavior.

### Description

- Added `createPluginCompatibilityValidators` and related helpers/types (`TemplateSettingsSchemaInput`, `checkTemplateSettingsSchemaCompatibilityInput`, `normalizeSchemaInput`) to `packages/skaff-lib/src/core/plugins/plugin-compatibility.ts` to expose unified validators that accept Zod or JSON schema input. 
- Implemented schema normalization & inspection utilities (`isZodSchema`, `normalizeSchemaInput`, `getJsonSchemaInfo`) and a JSON-schema based compatibility comparator used by the new validators.
- Replaced inline global-config and template-settings checks in `apps/web/src/lib/plugins/web-stage-loader.ts` with calls to the shared `createPluginCompatibilityValidators` helper and removed the duplicated logic.
- Updated `apps/cli/src/utils/plugin-manager.ts` to use the shared validators and pre-resolve registered plugin modules into a map, simplifying CLI validation flow while preserving existing CLI messaging helpers.

### Testing

- Ran the library test command `bun run test:skaff-lib` from the repo root which begins the build + test flow, and it failed during TypeScript compilation due to missing/changed exports in `@timonteutelink/template-types-lib` (type errors). 
- Also attempted `cd packages/skaff-lib && bun run test` which reproduced TypeScript errors referencing missing exports like `TemplatePluginConfig` and `ReadonlyProjectContext`, causing the test step to fail. 
- No unit tests were added in this change set; existing tests could not complete because the repository TypeScript surface did not match the installed `template-types-lib` build in this environment. 
- `bun install` was executed successfully during the rollout but did not resolve the type mismatch causing the CI-style `tsc` step to fail.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b344ed1688325ba458493e241c418)