### PR TITLE
Add sandboxed settings input transform hook for plugins and wire through CLI

### DIFF
--- a/apps/cli/src/utils/template-utils.ts
+++ b/apps/cli/src/utils/template-utils.ts
@@ -204,6 +204,11 @@ export async function readUserTemplateSettings(
   if ('error' in rootTpl) throw new Error(rootTpl.error)
   if (!rootTpl.data) throw new Error(`No template named "${rootTemplateName}"`)
 
+  const subTpl = rootTpl.data.template.findSubTemplate(templateName)
+  if (!subTpl) {
+    throw new Error(`No sub-template "${templateName}" in root template "${rootTemplateName}"`)
+  }
+
   const projectSettings: ProjectSettings =
     options?.projectSettings ??
     ({
@@ -228,5 +233,17 @@ export async function readUserTemplateSettings(
     throw new Error(pluginsResult.error)
   }
 
-  return parsedSettings
+  let transformedSettings: unknown = parsedSettings
+
+  for (const plugin of pluginsResult.data) {
+    if (!plugin.settingsInputTransform) continue
+    transformedSettings = plugin.settingsInputTransform(transformedSettings)
+  }
+
+  const parsedResult = subTpl.config.templateSettingsSchema.safeParse(transformedSettings ?? {})
+  if (!parsedResult.success) {
+    throw new Error(`Invalid template settings for "${templateName}": ${parsedResult.error.message}`)
+  }
+
+  return parsedResult.data as UserTemplateSettings
 }

--- a/packages/skaff-lib/src/core/plugins/plugin-loader.ts
+++ b/packages/skaff-lib/src/core/plugins/plugin-loader.ts
@@ -4,10 +4,13 @@ import type { Result } from "../../lib/types";
 import { getPluginSystemSettings } from "../../lib/config";
 import type { Template } from "../templates/Template";
 import {
+  BoundSettingsInputTransform,
   CliPluginContribution,
   LoadedTemplatePlugin,
   NormalizedTemplatePluginConfig,
   SkaffPluginModule,
+  SettingsInputTransformContext,
+  SettingsInputTransformHook,
   WebPluginContribution,
   normalizeTemplatePlugins,
   PluginManifest,
@@ -309,6 +312,31 @@ async function buildWebPlugin(
   return resolveEntrypoint<WebPluginContribution>(module.web, input);
 }
 
+function buildSettingsInputTransform(
+  module: SkaffPluginModule,
+  context: SettingsInputTransformContext,
+): Result<BoundSettingsInputTransform | undefined> {
+  const entrypoint = module.settingsInputTransform;
+  if (!entrypoint) return { data: undefined };
+
+  if (typeof entrypoint !== "function") {
+    return {
+      error: `Plugin ${module.manifest.name} settingsInputTransform must be a function`,
+    };
+  }
+
+  return {
+    data: (input: unknown) => {
+      const sandbox = resolveHardenedSandbox();
+      return sandbox.invokeFunctionWithArgs(
+        entrypoint as SettingsInputTransformHook,
+        input,
+        context,
+      );
+    },
+  };
+}
+
 
 function validateManifest(
   manifest: PluginManifest,
@@ -459,6 +487,20 @@ export async function loadPluginsForTemplate(
       projectContext,
     };
 
+    const settingsTransformContext: SettingsInputTransformContext = {
+      templateName: template.config.templateConfig.name,
+      projectContext,
+      options: reference.options,
+    };
+
+    const settingsInputTransform = buildSettingsInputTransform(
+      pluginModule,
+      settingsTransformContext,
+    );
+    if ("error" in settingsInputTransform) {
+      return { error: settingsInputTransform.error };
+    }
+
     const templatePlugin = buildTemplatePlugin(
       pluginModule,
       template,
@@ -482,6 +524,7 @@ export async function loadPluginsForTemplate(
       globalConfig: globalConfigResult.data,
       lifecycle: pluginModule.lifecycle,
       templatePlugin: templatePlugin.data,
+      settingsInputTransform: settingsInputTransform.data,
       cliPlugin,
       webPlugin,
     });

--- a/packages/skaff-lib/src/core/plugins/plugin-types.ts
+++ b/packages/skaff-lib/src/core/plugins/plugin-types.ts
@@ -586,6 +586,36 @@ export interface UiPluginFactoryInput {
   projectContext: ReadonlyProjectContext;
 }
 
+/**
+ * Context provided to plugin settings input transforms.
+ *
+ * This context intentionally exposes only template identity, read-only
+ * project metadata, and plugin-scoped options. No filesystem access is allowed.
+ */
+export interface SettingsInputTransformContext {
+  /** The template's unique name identifier */
+  templateName: string;
+  /** Read-only project metadata (name, author, root template) */
+  projectContext: ReadonlyProjectContext;
+  /** Plugin-specific options from the template configuration */
+  options?: unknown;
+}
+
+/**
+ * Hook to normalize or preprocess user template settings before validation.
+ */
+export type SettingsInputTransformHook = (
+  input: unknown,
+  context: SettingsInputTransformContext,
+) => UserTemplateSettings;
+
+/**
+ * A bound settings input transform that already captures its safe context.
+ */
+export type BoundSettingsInputTransform = (
+  input: unknown,
+) => UserTemplateSettings;
+
 export interface NormalizedTemplatePluginConfig {
   module: string;
   /** Semver version constraint for the plugin */
@@ -777,6 +807,11 @@ export interface SkaffPluginModule {
    */
   requiredTemplateSettingsSchema?: z.ZodObject<UserTemplateSettings>;
 
+  /**
+   * Optional hook to preprocess settings input before schema validation.
+   */
+  settingsInputTransform?: SettingsInputTransformHook;
+
   /** Template generation plugin entrypoint */
   template?: TemplatePluginEntrypoint;
 
@@ -813,6 +848,9 @@ export interface LoadedTemplatePlugin {
 
   /** Template generation plugin (if template capability) */
   templatePlugin?: TemplateGenerationPlugin;
+
+  /** Preprocess settings input before schema validation (sandboxed) */
+  settingsInputTransform?: BoundSettingsInputTransform;
 
   /** CLI contributions (if cli capability) */
   cliPlugin?: CliPluginContribution;

--- a/packages/skaff-lib/tests/plugin-loader.test.ts
+++ b/packages/skaff-lib/tests/plugin-loader.test.ts
@@ -304,6 +304,66 @@ describeIfSES("plugin loading", () => {
     expect(notices).toEqual(["hello web"]);
   });
 
+  it("runs settings input transforms with a sandboxed, minimal context", async () => {
+    const { baseDir, template, projectSettings } =
+      await createTemplateWorkspace();
+
+    const pluginPath = path.join(baseDir, "settings-plugin.cjs");
+    await fs.writeFile(
+      pluginPath,
+      [
+        "module.exports = {",
+        "  manifest: {",
+        "    name: 'settings-plugin',",
+        "    version: '0.0.0',",
+        "    capabilities: ['template'],",
+        "    supportedHooks: { template: [], cli: [], web: [] },",
+        "  },",
+        "  settingsInputTransform(input, context) {",
+        "    return {",
+        "      received: input,",
+        "      templateName: context.templateName,",
+        "      projectRepositoryName: context.projectContext.projectRepositoryName,",
+        "      projectAuthor: context.projectContext.projectAuthor,",
+        "      rootTemplateName: context.projectContext.rootTemplateName,",
+        "      hasInstantiatedTemplates: 'instantiatedTemplates' in context.projectContext,",
+        "      hasTemplateView: 'template' in context,",
+        "      options: context.options ?? null,",
+        "    };",
+        "  },",
+        "};",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const packageName = "settings-plugin-package";
+    await registerPluginModule(pluginPath, packageName);
+
+    template.config.plugins = [{ module: packageName, options: { flag: true } }];
+
+    const pluginsResult = await loadPluginsForTemplate(
+      template,
+      createReadonlyProjectContext(projectSettings),
+    );
+    if ("error" in pluginsResult) {
+      throw new Error(pluginsResult.error);
+    }
+
+    const loaded = pluginsResult.data[0]!;
+    const transformed = loaded.settingsInputTransform?.({ hello: "world" });
+
+    expect(transformed).toEqual({
+      received: { hello: "world" },
+      templateName: template.config.templateConfig.name,
+      projectRepositoryName: projectSettings.projectRepositoryName,
+      projectAuthor: projectSettings.projectAuthor,
+      rootTemplateName: projectSettings.rootTemplateName,
+      hasInstantiatedTemplates: false,
+      hasTemplateView: false,
+      options: { flag: true },
+    });
+  });
+
   it("rejects plugins with blocked imports in sandboxed exports", async () => {
     const { baseDir, template, projectSettings } =
       await createTemplateWorkspace();


### PR DESCRIPTION
### Motivation
- Provide a way for plugins to preprocess or normalize user-provided template settings before schema validation.
- Ensure settings transforms run with the same sandboxing guarantees as other plugin hooks to avoid leaking filesystem or environment access.
- Apply plugin-driven transformations when the CLI consumes an externally provided settings file so templates receive validated, plugin-aware inputs.
- Keep plugin API ergonomic by exposing a bounded transform that captures the minimal safe context for execution.

### Description
- Added `SettingsInputTransformContext`, `SettingsInputTransformHook`, and `BoundSettingsInputTransform` types and a `settingsInputTransform?` field to `SkaffPluginModule` in `packages/skaff-lib/src/core/plugins/plugin-types.ts`.
- Extended `loadPluginsForTemplate` in `packages/skaff-lib/src/core/plugins/plugin-loader.ts` to build a sandboxed, bound settings transform using `resolveHardenedSandbox().invokeFunctionWithArgs()` and return it on each `LoadedTemplatePlugin` as `settingsInputTransform`.
- Updated the CLI `readUserTemplateSettings` in `apps/cli/src/utils/template-utils.ts` to load plugins for the target template, run each plugin's `settingsInputTransform` in order on the parsed settings, and then validate the transformed result against the template's `templateSettingsSchema` before returning.
- Added an integration test in `packages/skaff-lib/tests/plugin-loader.test.ts` that verifies settings transforms run sandboxed with a minimal context and that the transform receives only `templateName`, `projectContext`, and `options`.

### Testing
- Ran the library test suite with `bun run test:skaff-lib`, which builds dependencies and runs the full Jest suite and completed successfully (all tests passed).
- Also ran `cd packages/skaff-lib && bun run test` to execute package-local tests, which succeeded.
- The new `plugin-loader` test verifies the transform behavior and passed as part of the overall test run.
- The sandbox invocation for transforms uses the existing `HardenedSandboxService` so no additional runtime sandbox tests were required beyond the suite above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b361404e08325aeba19ae95404c2b)