### PR TITLE
Expose build-time plugin trust helper in skaff-lib and use it in web registry generation

### DIFF
--- a/apps/web/scripts/generate-plugin-registry.ts
+++ b/apps/web/scripts/generate-plugin-registry.ts
@@ -26,28 +26,14 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { createRequire } from "node:module";
 import process from "node:process";
-type PluginTrustLevel =
-  | "official"
-  | "verified"
-  | "community"
-  | "private"
-  | "unknown";
-
-const OFFICIAL_PLUGIN_SCOPES = ["@skaff", "@timonteutelink"] as const;
+import {
+  determinePluginTrustBasic,
+  type PluginTrustLevel,
+} from "@timonteutelink/skaff-lib";
 
 interface ParsedPackageSpec {
   name: string;
   version?: string;
-}
-
-function isOfficialPlugin(packageName: string): boolean {
-  return OFFICIAL_PLUGIN_SCOPES.some((scope) =>
-    packageName.startsWith(`${scope}/`),
-  );
-}
-
-function determinePluginTrustBasic(packageName: string): PluginTrustLevel {
-  return isOfficialPlugin(packageName) ? "official" : "community";
 }
 
 function parsePackageSpec(packageSpec: string): ParsedPackageSpec {

--- a/packages/skaff-lib/src/browser.ts
+++ b/packages/skaff-lib/src/browser.ts
@@ -2,5 +2,6 @@ export { findTemplate, projectSearchPathKey } from "./utils/shared-utils";
 export * from './lib/types';
 export * from './lib/logger/types';
 export * from "./core/plugins/plugin-compatibility";
+export * from "./core/plugins/plugin-trust-basic";
 export * from "./core/plugins/plugin-types";
 export * from "./core/plugins/template-view";

--- a/packages/skaff-lib/src/core/plugins/index.ts
+++ b/packages/skaff-lib/src/core/plugins/index.ts
@@ -2,6 +2,7 @@ export * from "./plugin-loader";
 export * from "./plugin-types";
 export * from "./plugin-lifecycle";
 export * from "./plugin-compatibility";
+export * from "./plugin-trust-basic";
 export * from "./plugin-trust";
 export * from "./template-view";
 export * from "./package-spec";

--- a/packages/skaff-lib/src/core/plugins/plugin-trust-basic.ts
+++ b/packages/skaff-lib/src/core/plugins/plugin-trust-basic.ts
@@ -1,0 +1,45 @@
+/**
+ * Basic trust helpers that are safe to run in build-time environments.
+ */
+
+/**
+ * Trust levels for plugins based on their source and verification status.
+ *
+ * The trust hierarchy (from most to least trusted):
+ * 1. `official` - From @skaff/* or @timonteutelink/* scopes, maintained by Skaff team
+ * 2. `verified` - Has npm provenance attestation linking to source repository
+ * 3. `community` - Standard npm package without provenance
+ * 4. `private` - From a private registry (user's responsibility)
+ * 5. `unknown` - Trust level could not be determined
+ */
+export type PluginTrustLevel =
+  | "official"
+  | "verified"
+  | "community"
+  | "private"
+  | "unknown";
+
+/**
+ * Official Skaff plugin scopes that are fully trusted.
+ */
+export const OFFICIAL_PLUGIN_SCOPES = ["@skaff", "@timonteutelink"] as const;
+
+/**
+ * Determines if a package name is from an official Skaff scope.
+ */
+export function isOfficialPlugin(packageName: string): boolean {
+  return OFFICIAL_PLUGIN_SCOPES.some((scope) =>
+    packageName.startsWith(`${scope}/`),
+  );
+}
+
+/**
+ * Determines a trust level using only build-time safe checks.
+ *
+ * This avoids network or registry lookups, making it safe for web build steps.
+ */
+export function determinePluginTrustBasic(
+  packageName: string,
+): PluginTrustLevel {
+  return isOfficialPlugin(packageName) ? "official" : "community";
+}

--- a/packages/skaff-lib/src/core/plugins/plugin-types.ts
+++ b/packages/skaff-lib/src/core/plugins/plugin-types.ts
@@ -11,6 +11,12 @@ import type {
   TemplatePluginEntrypoint,
 } from "../generation/template-generation-types";
 import { z } from "zod";
+import type { PluginTrustLevel } from "./plugin-trust-basic";
+import {
+  determinePluginTrustBasic,
+  isOfficialPlugin,
+  OFFICIAL_PLUGIN_SCOPES,
+} from "./plugin-trust-basic";
 
 /**
  * Re-export ReadonlyProjectContext for plugin authors.
@@ -34,27 +40,8 @@ export type PluginCapability = "template" | "cli" | "web";
 // Plugin Trust Levels
 // =============================================================================
 
-/**
- * Trust levels for plugins based on their source and verification status.
- *
- * The trust hierarchy (from most to least trusted):
- * 1. `official` - From @skaff/* or @timonteutelink/* scopes, maintained by Skaff team
- * 2. `verified` - Has npm provenance attestation linking to source repository
- * 3. `community` - Standard npm package without provenance
- * 4. `private` - From a private registry (user's responsibility)
- * 5. `unknown` - Trust level could not be determined
- */
-export type PluginTrustLevel =
-  | "official"
-  | "verified"
-  | "community"
-  | "private"
-  | "unknown";
-
-/**
- * Official Skaff plugin scopes that are fully trusted.
- */
-export const OFFICIAL_PLUGIN_SCOPES = ["@skaff", "@timonteutelink"] as const;
+export type { PluginTrustLevel };
+export { OFFICIAL_PLUGIN_SCOPES, determinePluginTrustBasic, isOfficialPlugin };
 
 /**
  * Information about a plugin's trust status.
@@ -76,26 +63,6 @@ export interface PluginTrustInfo {
   reason: string;
   /** Warnings about the plugin's trust status (for non-official plugins) */
   warnings: string[];
-}
-
-/**
- * Determines if a package name is from an official Skaff scope.
- */
-export function isOfficialPlugin(packageName: string): boolean {
-  return OFFICIAL_PLUGIN_SCOPES.some((scope) =>
-    packageName.startsWith(`${scope}/`),
-  );
-}
-
-/**
- * Determines a trust level using only build-time safe checks.
- *
- * This avoids network or registry lookups, making it safe for web build steps.
- */
-export function determinePluginTrustBasic(
-  packageName: string,
-): PluginTrustLevel {
-  return isOfficialPlugin(packageName) ? "official" : "community";
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Centralize the build-time-safe plugin trust calculation so the Web registry generation and CLI share the same basic logic.
- Provide a small, reusable helper that can be imported during Web build steps without network or registry lookups.
- Remove duplicated trust logic from the Web registry generator so generated registries include `trustLevel` consistent with the library.
- Reduce maintenance surface by exporting the helper from `skaff-lib` (including the browser entrypoint) for build-time consumption.

### Description
- Added `packages/skaff-lib/src/core/plugins/plugin-trust-basic.ts` which exports `determinePluginTrustBasic`, `isOfficialPlugin`, `OFFICIAL_PLUGIN_SCOPES`, and the `PluginTrustLevel` type.
- Re-exported the new helper via `packages/skaff-lib/src/core/plugins/index.ts` and `packages/skaff-lib/src/browser.ts` so it is available to build-time consumers and browser builds.
- Updated `apps/web/scripts/generate-plugin-registry.ts` to import `determinePluginTrustBasic` and `PluginTrustLevel` from `@timonteutelink/skaff-lib` and removed the local duplicate implementation.
- Adjusted `packages/skaff-lib/src/core/plugins/plugin-types.ts` to import and re-export the basic trust types/helpers from the new module to keep public types stable.

### Testing
- Ran `bun run test:skaff-lib` from the repo root (invokes build + tests via `test:ci`) and the TypeScript build failed due to missing/changed exports in `@timonteutelink/template-types-lib` (test run failed).
- Ran `cd packages/skaff-lib && bun run test` which also failed during `tsc` with the same `template-types-lib` export/type errors (test run failed).
- Performed `bun install` to ensure dependencies were present; install completed but did not resolve the TypeScript build errors observed in the test runs.
- All automated test attempts failed due to unrelated type/export mismatches in `template-types-lib`, not due to the new helper wiring itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b3cb2db248325b90540f31ff96c3b)