### PR TITLE
Improve turbo/test commands and Makefile workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,24 @@
 - Skaff-lib and template-types-lib are referenced via their built JavaScript outputs. Always build both before running tests. Use `bun run test:skaff-lib` from the repo root (or `bun run test:ci` inside `packages/skaff-lib`) to run the builds + tests together.
 - If dependency state gets inconsistent, optionally run `make cr` before `bun install`, builds, and tests.
 
+## Testing guidance (detailed)
+The test flow depends on built outputs, so the safest path is:
+
+1. **Optional cleanup & install**
+   - `make cr` (removes lockfiles + node_modules for a clean install)
+   - `bun install`
+2. **Library-first test path (required before submitting)**
+   - `cd packages/skaff-lib && bun run test`
+     - This is the *required* full test suite check.
+     - Internally it runs the build prerequisites and then Jest.
+3. **Repo-wide tests (optional but recommended when touching CLI/Web/examples)**
+   - `bun run test` (Turbo runs `test` across all packages that expose it)
+   - `bun run test:cli` (CLI-specific test suite)
+   - `bun run test:skaff-lib` (builds template-types + skaff-lib + plugin types, then runs Jest)
+
+If you just need the single-command "build + test" pipeline for skaff-lib, use:
+`bun run test:skaff-lib`
+
 ## General expectations
 - Ensure any documentation edits remain consistent across the repo.
 - When touching documentation, always look for opportunities to improve clarity or completeness.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
-all: install-types build-types install-lib build-lib install-repo build-cli build-cli-nix build-web build-web-docker build-web-nix
+all: build-all
 	@echo "Built everything!"
+
+install:
+	bun install
+	@echo "Installed workspace dependencies!"
 
 install-types:
 	cd packages/template-types-lib && bun i
@@ -31,6 +35,18 @@ install-repo:
 
 ir: install-repo
 
+build:
+	bun run build
+	@echo "Built all Turbo packages!"
+
+build-libs:
+	bun run build:libs
+	@echo "Built all library packages!"
+
+build-apps:
+	bun run build:apps
+	@echo "Built all app packages!"
+
 build-cli:
 	cd apps/cli && bun run build:dist
 	@echo "Built CLI!"
@@ -47,6 +63,12 @@ build-web:
 	@echo "Built web!"
 
 bw: build-web
+
+build-web-nix:
+	nix build .#skaff-web
+	@echo "Built web via Nix!"
+
+bwn: build-web-nix
 
 build-web-docker:
 	cd apps/web && ./docker/build.sh
@@ -104,13 +126,34 @@ monorepo-prod:
 
 mp: monorepo-prod
 
-build-all: it il ir bt bl bc
+build-all: it il ir bt bl bc bw
+	@echo "Built core libs + CLI + Web!"
 
 ba: build-all
 
 build-all-all: build-all bwd
 
 baa: build-all-all
+
+test:
+	bun run test
+	@echo "Ran all Turbo test scripts!"
+
+test-skaff-lib:
+	cd packages/skaff-lib && bun run test
+	@echo "Ran skaff-lib test suite!"
+
+test-cli:
+	cd apps/cli && bun run test
+	@echo "Ran CLI test suite!"
+
+lint:
+	bun run lint
+	@echo "Ran all Turbo lint scripts!"
+
+check-types:
+	bun run check-types
+	@echo "Ran all Turbo type checks!"
 
 clean-repo:
 	rm -rf bun.lock node_modules apps/cli/node_modules apps/web/node_modules packages/template-types-lib/node_modules packages/template-types-lib/bun.lock packages/skaff-lib/node_modules packages/skaff-lib/bun.lock 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,16 @@ for the full guide. In summary:
 - Work on a feature branch and open a Pull Request against `main`. PRs run continuous integration and should be kept focused
 - Releases are handled by maintainers via semantic versioning and GitHub Actions; you usually don’t need to publish packages yourself
 
+### Helpful local commands
+
+The Makefile and Turbo scripts expose short-hands for common flows:
+
+- **Clean + install:** `make cr && bun install`
+- **Build everything (libs + apps):** `make build-all`
+- **Build everything incl. Docker web image:** `make build-all-all`
+- **Run all tests registered in workspaces:** `bun run test`
+- **Run the required skaff-lib test suite:** `cd packages/skaff-lib && bun run test`
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for details.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -89,8 +89,10 @@
   },
   "repository": "timonteutelink/skaff",
   "scripts": {
-    "rundev": "",
+    "dev": "oclif dev",
     "build": "rm -rf dist && tsc -b",
+    "check-types": "tsc --noEmit",
+    "clean": "rm -rf dist oclif.manifest.json",
     "lint": "eslint",
     "postpack": "rm -f oclif.manifest.json",
     "posttest": "true",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,12 +4,14 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "clean": "rm -rf .next",
     "dev": "bun run generate:plugins && next dev --webpack --port 3000",
     "build": "bun run generate:plugins && next build --webpack",
     "start": "next start",
     "lint": "bun run generate:plugins && next lint --max-warnings 0",
     "check-types": "bun run generate:plugins && tsc --noEmit",
-    "generate:plugins": "bun run scripts/generate-plugin-registry.ts"
+    "generate:plugins": "bun run scripts/generate-plugin-registry.ts",
+    "test": "bun run lint && bun run check-types"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/examples/plugins/plugin-greeter-cli/package.json
+++ b/examples/plugins/plugin-greeter-cli/package.json
@@ -14,7 +14,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "check-types": "tsc --noEmit",
+    "clean": "rm -rf dist",
+    "test": "bun run build"
   },
   "dependencies": {
     "@timonteutelink/skaff-plugin-greeter": "workspace:*",

--- a/examples/plugins/plugin-greeter-types/package.json
+++ b/examples/plugins/plugin-greeter-types/package.json
@@ -14,10 +14,15 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "check-types": "tsc --noEmit",
+    "clean": "rm -rf dist",
+    "test": "bun run build"
+  },
+  "dependencies": {
+    "@timonteutelink/template-types-lib": "workspace:*"
   },
   "devDependencies": {
-    "@timonteutelink/template-types-lib": "workspace:*",
     "typescript": "5.9.3"
   }
 }

--- a/examples/plugins/plugin-greeter-web/package.json
+++ b/examples/plugins/plugin-greeter-web/package.json
@@ -14,7 +14,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "check-types": "tsc --noEmit",
+    "clean": "rm -rf dist",
+    "test": "bun run build"
   },
   "dependencies": {
     "@timonteutelink/skaff-plugin-greeter": "workspace:*",

--- a/examples/plugins/plugin-greeter/package.json
+++ b/examples/plugins/plugin-greeter/package.json
@@ -14,7 +14,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "check-types": "tsc --noEmit",
+    "clean": "rm -rf dist",
+    "test": "bun run build"
   },
   "dependencies": {
     "@timonteutelink/skaff-plugin-greeter-types": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,23 @@
   "name": "skaff",
   "private": true,
   "scripts": {
+    "build": "turbo run build",
+    "build:apps": "turbo run build --filter=./apps/*",
+    "build:cli": "turbo run build --filter=./apps/cli",
+    "build:web": "turbo run build --filter=./apps/web",
+    "build:libs": "turbo run build --filter=./packages/*",
+    "build:plugins": "turbo run build --filter=./examples/plugins/*",
     "buildNixWeb": "nix-web && bun i && git add -A && nix build .#skaff-web",
     "buildNixCli": "nix-cli && bun i && git add -A && nix build .#skaff-cli",
+    "check-types": "turbo run check-types",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "postinstall": "./scripts/bun2nix.sh || exit 0",
+    "lint": "turbo run lint",
+    "test": "turbo run test --concurrency=1",
+    "test:apps": "turbo run test --filter=./apps/* --concurrency=1",
+    "test:cli": "turbo run test --filter=./apps/cli --concurrency=1",
+    "test:libs": "turbo run test --filter=./packages/* --concurrency=1",
+    "test:plugins": "turbo run test --filter=./examples/plugins/* --concurrency=1",
     "test:skaff-lib": "cd packages/skaff-lib && bun run test:ci"
   },
   "devDependencies": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -3,6 +3,7 @@
 	"private": true,
 	"packageManager": "bun@1.2.15",
 	"scripts": {
+		"build": "bun run docs",
 		"dev": "docusaurus start --port 3100",
 		"clean": "rm -rf build .docusaurus src/docs/skaff-lib src/docs/lib src/docs/template-types-lib src/docs/cli dist temp",
 		"gen:template-types-lib-api": "cd ../template-types-lib && bun run build && cd ../docs && mkdir -p src/docs/template-types-lib && api-extractor run -c template-types-lib-api-extractor.json --local --verbose",
@@ -10,7 +11,8 @@
 		"gen:cli": "cd ../../apps/cli && bun run build:dist && oclif readme --multi --output-dir=../../packages/docs/src/docs/cli && cd ../../packages/docs",
 		"docs": "bun run gen:template-types-lib-api && bun run gen:skaff-lib-api && bun run gen:cli && cp src/extra-pages/cli-index.mdx src/docs/cli/index.mdx && docusaurus build",
 		"devdocs": "bun run gen:template-types-lib-api && bun run gen:skaff-lib-api && bun run gen:cli && cp src/extra-pages/cli-index.mdx src/docs/cli/index.mdx && docusaurus start --port 3100",
-		"serve": "docusaurus serve"
+		"serve": "docusaurus serve",
+		"test": "bun run build"
 	},
 	"devDependencies": {
 		"@docusaurus/core": "^3.9.2",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -8,6 +8,10 @@
     "./next-js": "./next.js",
     "./react-internal": "./react-internal.js"
   },
+  "scripts": {
+    "build": "echo \"No build step for @repo/eslint-config\"",
+    "test": "echo \"No tests for @repo/eslint-config\""
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@next/eslint-plugin-next": "^16.0.3",

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -7,6 +7,7 @@
 	},
 	"scripts": {
 		"jupyter": "deno task jupyter",
-		"install-jupyter": "deno task install-jupyter"
+		"install-jupyter": "deno task install-jupyter",
+		"test": "echo \"No automated tests for @repo/notebook\""
 	}
 }

--- a/packages/skaff-lib/package.json
+++ b/packages/skaff-lib/package.json
@@ -21,6 +21,7 @@
   ],
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
     "lint": "eslint . --max-warnings 0",
     "check-types": "tsc --noEmit",
     "test": "bun run test:ci",

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -5,6 +5,10 @@
   "exports": {
     ".": "./tailwind.config.ts"
   },
+  "scripts": {
+    "build": "echo \"No build step for @repo/tailwind-config\"",
+    "test": "echo \"No tests for @repo/tailwind-config\""
+  },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
     "tailwindcss": "^4.1.17"

--- a/packages/template-types-lib/package.json
+++ b/packages/template-types-lib/package.json
@@ -18,7 +18,9 @@
   "scripts": {
     "lint": "eslint . --max-warnings 0",
     "check-types": "tsc --noEmit",
-    "build": "rm -rf dist && tsc -p tsconfig.json"
+    "build": "rm -rf dist && tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
+    "test": "bun run lint && bun run check-types"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "license": "MIT",
+  "scripts": {
+    "build": "echo \"No build step for @repo/typescript-config\"",
+    "test": "echo \"No tests for @repo/typescript-config\""
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/turbo.json
+++ b/turbo.json
@@ -11,8 +11,15 @@
         ".env*"
       ],
       "outputs": [
+        "dist/**",
         ".next/**",
         "!.next/cache/**"
+      ]
+    },
+    "test": {
+      "dependsOn": [
+        "^build",
+        "^test"
       ]
     },
     "lint": {


### PR DESCRIPTION
### Motivation

- Provide a single, consistent way to build and test the monorepo via Turbo and the Makefile. 
- Ensure packages expose standard `build`, `test`, `clean`, and `check-types` scripts so `turbo` and `make` can orchestrate workflows. 
- Make it easier to run the required `skaff-lib` prebuild/test flow (template types must be built first). 
- Document the recommended local build & test flows in `AGENTS.md` and `README.md`.

### Description

- Added Turbo `build` outputs and a `test` task and added repo-level scripts in the root `package.json` for `build`, `build:apps`, `build:libs`, `test` (and filtered variants), `lint`, and `check-types` using `turbo`.
- Extended the `Makefile` with `install`, `build`, `build-libs`, `build-apps`, `build-all`, `test`, `test-skaff-lib`, `test-cli`, `lint`, and `check-types` targets and wired them to the Turbo scripts and existing package scripts.
- Standardized and improved `package.json` scripts across `apps/cli`, `apps/web`, `packages/*`, and `examples/plugins/*` to expose `build`, `clean`, `check-types`, and `test` where appropriate, and added lightweight `build`/`test` entries for config packages.
- Updated `AGENTS.md` and `README.md` with explicit test/build instructions and recommended command sequences (including `make cr && bun install`, `bun run test:skaff-lib`, and `bun run test`).

### Testing

- Ran the full `skaff-lib` test suite with `cd packages/skaff-lib && bun run test`; all automated tests passed (31 test suites, 215 tests).
- Ran the repo-wide test orchestration via `bun run test` (`turbo run test --concurrency=1`); this exercised Turbo across packages but failed due to a single CLI integration test (`apps/cli`) asserting an exact stdout format (the test `creates a new project from templates/test-templates` did not match the expected regex).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b377a944c8325970b1eff4c16666a)