### PR TITLE
Defer SES lockdown until sandbox use

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Skaff executes user‑provided template code (such as `templateConfig.ts` and pl
 | **No process/environment**  | `process`, `child_process` and environment variables are blocked.                                                                                                              |
 | **Frozen intrinsics**       | All built‑in prototypes (`Object`, `Array`, `Function`, etc.) are frozen after `lockdown()`, preventing prototype pollution.                                                   |
 | **Deterministic execution** | `Date.now()` and `Math.random()` are disabled by default for reproducible builds.                                                                                              |
-| **Whitelisted imports**     | Only explicitly allowed modules can be `require()`d: `yaml`, `zod`, `handlebars`, and `@timonteutelink/template-types-lib`. Plugins may receive extra environment-registered stubs (for example, the Web UI registers a minimal React stub via `registerPluginSandboxLibraries`). |
+| **Whitelisted imports**     | Only explicitly allowed modules can be `require()`d: `yaml`, `zod`, and `@timonteutelink/template-types-lib`. Plugins may receive extra environment-registered stubs (for example, the Web UI registers a minimal React stub via `registerPluginSandboxLibraries`). |
 
 ### Where sandboxing is applied
 

--- a/apps/web/src/components/general/projects/types.ts
+++ b/apps/web/src/components/general/projects/types.ts
@@ -1,6 +1,6 @@
 import type {
 	TemplateDTO,
-} from "@timonteutelink/skaff-lib";
+} from "@timonteutelink/skaff-lib/browser";
 
 /* =============================================================================
 	 Tree Node Types

--- a/apps/web/src/lib/logger.ts
+++ b/apps/web/src/lib/logger.ts
@@ -2,7 +2,7 @@
 
 import log, { LogLevelDesc } from "loglevel";
 import { logFromClient } from "@/app/actions/logs";
-import { LevelName } from "@timonteutelink/skaff-lib";
+import { LevelName } from "@timonteutelink/skaff-lib/browser";
 
 const defaultLevel: LogLevelDesc =
   (process.env.NEXT_PUBLIC_LOG_LEVEL as LogLevelDesc) ?? "info";
@@ -27,4 +27,3 @@ const logger = {
 };
 
 export default logger;
-

--- a/apps/web/src/lib/plugins/plugin-types.ts
+++ b/apps/web/src/lib/plugins/plugin-types.ts
@@ -2,7 +2,7 @@ import type React from "react";
 import type {
   WebPluginContribution as BaseWebPluginContribution,
   WebTemplateStage as BaseWebTemplateStage,
-} from "@timonteutelink/skaff-lib";
+} from "@timonteutelink/skaff-lib/browser";
 
 export type WebTemplateStage<TState = unknown> = BaseWebTemplateStage<
   TState,

--- a/packages/skaff-lib/src/core/infra/hardened-sandbox.ts
+++ b/packages/skaff-lib/src/core/infra/hardened-sandbox.ts
@@ -160,14 +160,12 @@ export function markHardenedEnvironmentForTesting(): void {
 }
 
 /**
- * Ensures the hardened environment is initialized, throwing if not.
+ * Ensures the hardened environment is initialized.
  * Call this before any sandbox operations.
  */
 export function ensureHardenedEnvironment(): void {
   if (!isLockedDown) {
-    throw new Error(
-      "Hardened environment not initialized. Call initializeHardenedEnvironment() before using the sandbox.",
-    );
+    initializeHardenedEnvironment();
   }
 }
 

--- a/packages/skaff-lib/src/index.ts
+++ b/packages/skaff-lib/src/index.ts
@@ -1,9 +1,3 @@
-// Initialize the hardened environment as early as possible
-import { initializeHardenedEnvironment } from "./core/infra/hardened-sandbox";
-if (typeof window === "undefined") {
-  initializeHardenedEnvironment();
-}
-
 import type { CacheKey } from "./core/infra/cache-service";
 
 export * from "./repositories";

--- a/packages/skaff-plugin-erd-web/src/index.tsx
+++ b/packages/skaff-plugin-erd-web/src/index.tsx
@@ -6,7 +6,7 @@ import type {
   TemplateStageRenderProps,
   WebPluginContribution,
   WebPluginEntrypoint,
-} from "@timonteutelink/skaff-lib";
+} from "@timonteutelink/skaff-lib/browser";
 import {
   mapErdToSettings,
   mapSettingsToErd,


### PR DESCRIPTION
### Motivation

- Avoid hardening the entire process on import so consumers (e.g., Next.js server runtimes) are not globally locked down by simply importing the library.
- Confine SES setup to execution paths that actually run untrusted template or plugin code to reduce runtime impact and compatibility issues.

### Description

- Remove the top-level `initializeHardenedEnvironment()` call from `packages/skaff-lib/src/index.ts` so importing the package no longer triggers lockdown.
- Make `ensureHardenedEnvironment()` lazily call `initializeHardenedEnvironment()` in `packages/skaff-lib/src/core/infra/hardened-sandbox.ts` so the environment is initialized on-demand before sandbox operations.
- Update the README sandbox whitelist to reflect the actual allowed modules by removing `handlebars` from the listed imports.

### Testing

- Ran `cd packages/skaff-lib && bun run test` which failed due to `template-types-lib` export mismatches reported by TypeScript.
- Ran `cd packages/template-types-lib && bun run build` which completed successfully.
- Ran `bun install` to refresh dependencies which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ef60865208325a1917e954c8961f1)