### PR TITLE
Use browser entrypoints in client web imports

### DIFF
--- a/apps/web/src/components/general/projects/types.ts
+++ b/apps/web/src/components/general/projects/types.ts
@@ -1,6 +1,6 @@
 import type {
 	TemplateDTO,
-} from "@timonteutelink/skaff-lib";
+} from "@timonteutelink/skaff-lib/browser";
 
 /* =============================================================================
 	 Tree Node Types

--- a/apps/web/src/lib/logger.ts
+++ b/apps/web/src/lib/logger.ts
@@ -2,7 +2,7 @@
 
 import log, { LogLevelDesc } from "loglevel";
 import { logFromClient } from "@/app/actions/logs";
-import { LevelName } from "@timonteutelink/skaff-lib";
+import { LevelName } from "@timonteutelink/skaff-lib/browser";
 
 const defaultLevel: LogLevelDesc =
   (process.env.NEXT_PUBLIC_LOG_LEVEL as LogLevelDesc) ?? "info";
@@ -27,4 +27,3 @@ const logger = {
 };
 
 export default logger;
-

--- a/apps/web/src/lib/plugins/plugin-types.ts
+++ b/apps/web/src/lib/plugins/plugin-types.ts
@@ -2,7 +2,7 @@ import type React from "react";
 import type {
   WebPluginContribution as BaseWebPluginContribution,
   WebTemplateStage as BaseWebTemplateStage,
-} from "@timonteutelink/skaff-lib";
+} from "@timonteutelink/skaff-lib/browser";
 
 export type WebTemplateStage<TState = unknown> = BaseWebTemplateStage<
   TState,

--- a/packages/skaff-plugin-erd-web/src/index.tsx
+++ b/packages/skaff-plugin-erd-web/src/index.tsx
@@ -6,7 +6,7 @@ import type {
   TemplateStageRenderProps,
   WebPluginContribution,
   WebPluginEntrypoint,
-} from "@timonteutelink/skaff-lib";
+} from "@timonteutelink/skaff-lib/browser";
 import {
   mapErdToSettings,
   mapSettingsToErd,


### PR DESCRIPTION
### Motivation
- Ensure client-rendered web code imports the browser-only entrypoint of the library so server/runtime-only APIs are not bundled into client code.
- Align web plugin entrypoints and shared client-facing types with the `@timonteutelink/skaff-lib/browser` build to keep the client bundle safe and consistent.

### Description
- Switched imports from `@timonteutelink/skaff-lib` to `@timonteutelink/skaff-lib/browser` in client files.
- Updated the following files: `apps/web/src/lib/logger.ts`, `apps/web/src/lib/plugins/plugin-types.ts`, `apps/web/src/components/general/projects/types.ts`, and `packages/skaff-plugin-erd-web/src/index.tsx`.
- Updated the ERD web plugin entrypoint and shared project type definitions so client code uses browser exports.

### Testing
- Ran `bun install` to ensure dependencies were up-to-date before testing.
- Ran `cd packages/skaff-lib && bun run test` and all test suites passed (31 test suites, 216 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695efb394c748325b51359663386dff3)