### PR TITLE
Remove CLI bundle expansion from web plugin registry

### DIFF
--- a/apps/web/scripts/generate-plugin-registry.ts
+++ b/apps/web/scripts/generate-plugin-registry.ts
@@ -15,7 +15,6 @@
  *   bun run scripts/generate-plugin-registry.ts
  *
  * The script reads from:
- *   - package.json dependencies
  *   - SKAFF_PLUGINS environment variable (space-separated list)
  *
  * And generates:
@@ -85,12 +84,8 @@ interface PluginManifest {
 interface PluginPackageJson {
   name: string;
   version: string;
-  main?: string;
-  exports?: Record<string, string> | string;
   skaff?: {
-    plugin?: boolean;
     bundle?: {
-      cli?: string;
       web?: string;
     };
   };
@@ -156,40 +151,37 @@ function getPackageJson(packageName: string): PluginPackageJson | null {
   }
 }
 
+const DEV_DEFAULT_PLUGINS = ["@skaff/plugin-greeter"];
+
+function shouldIncludeDevDefaults(): boolean {
+  return (
+    process.env.NODE_ENV === "development" ||
+    process.env.SKAFF_DEV_PLUGINS === "1" ||
+    process.env.SKAFF_DEV_TEMPLATES === "1"
+  );
+}
+
 /**
  * Discovers plugins from environment variable
  */
 function getPluginsFromEnv(): string[] {
   const envPlugins = process.env.SKAFF_PLUGINS ?? "";
-  return envPlugins
+  const plugins = envPlugins
     .split(/\s+/)
     .map((p: string) => p.trim())
     .filter(Boolean)
     .map((spec: string) => parsePackageSpec(spec).name);
-}
 
-/**
- * Discovers plugins from package.json dependencies
- * Only considers packages with "skaff-plugin" or "@skaff/" in the name
- */
-function getPluginsFromPackageJson(): string[] {
-  try {
-    const pkgPath = resolve(WEB_ROOT, "package.json");
-    const content = readFileSync(pkgPath, "utf-8");
-    const pkg = JSON.parse(content);
-
-    const deps = {
-      ...pkg.dependencies,
-      ...pkg.devDependencies,
-    };
-
-    return Object.keys(deps);
-  } catch {
-    return [];
+  if (shouldIncludeDevDefaults()) {
+    for (const plugin of DEV_DEFAULT_PLUGINS) {
+      plugins.push(plugin);
+    }
   }
+
+  return [...new Set(plugins)];
 }
 
-function expandWebBundles(packageNames: string[]): string[] {
+function expandBundledPlugins(packageNames: string[]): string[] {
   const expanded = new Set<string>(packageNames);
 
   for (const packageName of packageNames) {
@@ -208,12 +200,9 @@ function expandWebBundles(packageNames: string[]): string[] {
  */
 async function discoverPlugins(): Promise<DiscoveredPlugin[]> {
   const envPlugins = getPluginsFromEnv();
-  const pkgPlugins = getPluginsFromPackageJson();
 
   // Combine and deduplicate
-  const allPackages = expandWebBundles([
-    ...new Set([...envPlugins, ...pkgPlugins]),
-  ]);
+  const allPackages = expandBundledPlugins([...new Set(envPlugins)]);
 
   console.log(`Scanning ${allPackages.length} potential plugin packages...`);
 
@@ -295,8 +284,7 @@ function generateRegistryFile(plugins: DiscoveredPlugin[]): string {
  * This file is generated at build time by scripts/generate-plugin-registry.ts
  * It contains static imports for all installed Skaff web plugins.
  *
- * To add or remove plugins, modify the SKAFF_PLUGINS build argument or
- * update package.json dependencies, then rebuild.
+ * To add or remove plugins, modify the SKAFF_PLUGINS build argument, then rebuild.
  *
  * Generated: ${new Date().toISOString()}
  */

--- a/bun.lock
+++ b/bun.lock
@@ -2704,9 +2704,15 @@
 
     "@babel/helpers/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
+    "@babel/parser/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
     "@babel/template/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
 
     "@babel/template/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "@babel/traverse/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
+
+    "@babel/traverse/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
     "@babel/traverse/globals": ["globals@11.12.0", "", {}, "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="],
 


### PR DESCRIPTION
### Motivation

- Restrict web plugin discovery to only packages explicitly listed via `SKAFF_PLUGINS` (plus dev defaults) and eliminate implicit package.json scanning. 
- Remove handling for CLI-bundled variants since the web app never imports CLI plugins. 
- Simplify the generator code and eliminate unused functions and branches introduced for package.json-based discovery. 

### Description

- Removed `skaff.bundle.cli` handling and the `cli` bundle expansion from the registry generator and from the `PluginPackageJson` shape. 
- Deleted package.json scanning by removing `getPluginsFromPackageJson()` and changed discovery to use only `getPluginsFromEnv()` with `DEV_DEFAULT_PLUGINS` when appropriate. 
- Replaced/renamed the bundle expansion to `expandBundledPlugins()` which only expands `skaff.bundle.web`, and updated the build-time registry header to mention `SKAFF_PLUGINS` only. 
- Updated `bun.lock` after reinstall to reflect dependency state. 

### Testing

- Ran the package test suite with `cd packages/skaff-lib && bun run test`. 
- All automated tests passed: `31` test suites and `216` tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f0209f8b48325bf3b2085ba4bdbd1)