### PR TITLE
Fix web plugin registry SES dependency and ensure ERD web plugin loads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,14 @@ build-web:
 
 bw: build-web
 
+build-erd-plugins:
+	cd packages/skaff-plugin-erd-types && bun run build
+	cd packages/skaff-plugin-erd && bun run build
+	cd packages/skaff-plugin-erd-web && bun run build
+	@echo "Built ERD plugins!"
+
+bep: build-erd-plugins
+
 build-web-nix:
 	nix build .#skaff-web
 	@echo "Built web via Nix!"
@@ -126,7 +134,7 @@ monorepo-prod:
 
 mp: monorepo-prod
 
-build-all: it il ir bt bl bc bw
+build-all: it il ir bt bl bep bc bw
 	@echo "Built core libs + CLI + Web!"
 
 ba: build-all

--- a/apps/cli/src/utils/plugin-manager.ts
+++ b/apps/cli/src/utils/plugin-manager.ts
@@ -9,7 +9,6 @@ import {Config} from '@oclif/core'
 import {createRequire} from 'node:module'
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import {pathToFileURL} from 'node:url'
 import * as skaffLib from '@timonteutelink/skaff-lib'
 import type {
   InstalledPluginInfo,
@@ -77,6 +76,39 @@ export function parsePluginBundleMetadata(packageJson: unknown): PluginBundleMet
   return {cli, web}
 }
 
+async function resolvePackageJsonPath(modulePath: string): Promise<string | null> {
+  let currentDir = path.dirname(modulePath)
+
+  while (currentDir && currentDir !== path.dirname(currentDir)) {
+    const candidate = path.join(currentDir, 'package.json')
+    try {
+      await fs.stat(candidate)
+      return candidate
+    } catch {
+      currentDir = path.dirname(currentDir)
+    }
+  }
+
+  return null
+}
+
+async function readPackageJson(
+  requireFromDataDir: NodeRequire,
+  packageName: string,
+): Promise<unknown | null> {
+  try {
+    const modulePath = requireFromDataDir.resolve(packageName)
+    const packageJsonPath = await resolvePackageJsonPath(modulePath)
+    if (!packageJsonPath) {
+      return null
+    }
+    const raw = await fs.readFile(packageJsonPath, 'utf8')
+    return JSON.parse(raw) as unknown
+  } catch {
+    return null
+  }
+}
+
 async function getDataDirDependencyNames(config: Config): Promise<string[]> {
   try {
     const packagePath = path.join(config.dataDir, 'package.json')
@@ -94,9 +126,10 @@ export async function getInstalledPluginBundleMetadata(
 ): Promise<PluginBundleMetadata | null> {
   try {
     const requireFromDataDir = createRequire(path.join(config.dataDir, 'package.json'))
-    const pkgPath = requireFromDataDir.resolve(`${packageName}/package.json`)
-    const raw = await fs.readFile(pkgPath, 'utf8')
-    const packageJson = JSON.parse(raw) as unknown
+    const packageJson = await readPackageJson(requireFromDataDir, packageName)
+    if (!packageJson) {
+      return null
+    }
     return parsePluginBundleMetadata(packageJson)
   } catch {
     return null
@@ -191,18 +224,16 @@ export async function getInstalledCliPlugins(config: Config): Promise<SkaffCliPl
     let isSkaffPlugin = false
     let capabilities: ('template' | 'cli' | 'web')[] | undefined
 
-    try {
-      const requireFromPlugin = createRequire(path.join(plugin.root, 'package.json'))
-      const modulePath = requireFromPlugin.resolve(plugin.name)
-      const pluginModule = await import(pathToFileURL(modulePath).href)
-      const defaultExport = pluginModule.default ?? pluginModule
-
-      if (defaultExport?.manifest?.capabilities) {
-        isSkaffPlugin = true
-        capabilities = defaultExport.manifest.capabilities
-      }
-    } catch {
-      // Plugin doesn't have a loadable Skaff manifest - that's ok
+    const requireFromPlugin = createRequire(path.join(plugin.root, 'package.json'))
+    const packageJson = await readPackageJson(requireFromPlugin, plugin.name)
+    const manifestResult = skaffLib.pluginManifestSchema.safeParse(
+      packageJson && typeof packageJson === 'object'
+        ? (packageJson as {skaff?: {manifest?: unknown}}).skaff?.manifest
+        : undefined,
+    )
+    if (manifestResult.success) {
+      isSkaffPlugin = true
+      capabilities = manifestResult.data.capabilities
     }
 
     // Determine trust level
@@ -230,15 +261,15 @@ export async function getInstalledCliPlugins(config: Config): Promise<SkaffCliPl
       }
 
       try {
-        const modulePath = requireFromDataDir.resolve(dependencyName)
-        const packageJsonPath = path.join(path.dirname(modulePath), '..', 'package.json')
-        const packageRaw = await fs.readFile(packageJsonPath, 'utf8')
-        const packageInfo = JSON.parse(packageRaw) as {name?: string; version?: string}
-        const pluginModule = await import(pathToFileURL(modulePath).href)
-        const defaultExport = pluginModule.default ?? pluginModule
-
-        const isSkaffPlugin = Boolean(defaultExport?.manifest?.capabilities)
-        const capabilities = isSkaffPlugin ? defaultExport.manifest.capabilities : undefined
+        const packageJson = await readPackageJson(requireFromDataDir, dependencyName)
+        const manifestResult = skaffLib.pluginManifestSchema.safeParse(
+          packageJson && typeof packageJson === 'object'
+            ? (packageJson as {skaff?: {manifest?: unknown}}).skaff?.manifest
+            : undefined,
+        )
+        const isSkaffPlugin = manifestResult.success
+        const capabilities = manifestResult.success ? manifestResult.data.capabilities : undefined
+        const packageInfo = (packageJson ?? {}) as {name?: string; version?: string}
         const packageName = packageInfo.name ?? dependencyName
 
         plugins.push({
@@ -272,7 +303,7 @@ export async function getInstalledSkaffPlugins(config: Config): Promise<SkaffCli
  * Registers installed Skaff plugin modules so they can be activated by templates.
  */
 export async function registerInstalledPluginModules(config: Config): Promise<void> {
-  const entries: { moduleExports: unknown; modulePath: string; packageName: string }[] = []
+  const entries: { modulePath: string; packageName: string; manifest: skaffLib.PluginManifest }[] = []
   const seenPackages = new Set<string>()
 
   for (const plugin of config.getPluginsList()) {
@@ -280,24 +311,24 @@ export async function registerInstalledPluginModules(config: Config): Promise<vo
       continue
     }
 
-    try {
-      const requireFromPlugin = createRequire(path.join(plugin.root, 'package.json'))
-      const modulePath = requireFromPlugin.resolve(plugin.name)
-      const moduleNamespace = await import(pathToFileURL(modulePath).href)
-      const candidate = moduleNamespace.default ?? moduleNamespace
-      if (!candidate?.manifest?.capabilities) {
-        continue
-      }
-
-      entries.push({
-        moduleExports: moduleNamespace,
-        modulePath,
-        packageName: plugin.name,
-      })
-      seenPackages.add(plugin.name)
-    } catch {
-      // Ignore plugins that fail to import; they are treated as not installed
+    const requireFromPlugin = createRequire(path.join(plugin.root, 'package.json'))
+    const packageJson = await readPackageJson(requireFromPlugin, plugin.name)
+    const manifestResult = skaffLib.pluginManifestSchema.safeParse(
+      packageJson && typeof packageJson === 'object'
+        ? (packageJson as {skaff?: {manifest?: unknown}}).skaff?.manifest
+        : undefined,
+    )
+    if (!manifestResult.success) {
+      continue
     }
+
+    const modulePath = requireFromPlugin.resolve(plugin.name)
+    entries.push({
+      modulePath,
+      packageName: plugin.name,
+      manifest: manifestResult.data,
+    })
+    seenPackages.add(plugin.name)
   }
 
   const dependencyNames = await getDataDirDependencyNames(config)
@@ -309,23 +340,23 @@ export async function registerInstalledPluginModules(config: Config): Promise<vo
         continue
       }
 
-      try {
-        const modulePath = requireFromDataDir.resolve(dependencyName)
-        const moduleNamespace = await import(pathToFileURL(modulePath).href)
-        const candidate = moduleNamespace.default ?? moduleNamespace
-        if (!candidate?.manifest?.capabilities) {
-          continue
-        }
-
-        entries.push({
-          moduleExports: moduleNamespace,
-          modulePath,
-          packageName: dependencyName,
-        })
-        seenPackages.add(dependencyName)
-      } catch {
-        // Ignore non-plugin dependencies
+      const modulePath = requireFromDataDir.resolve(dependencyName)
+      const packageJson = await readPackageJson(requireFromDataDir, dependencyName)
+      const manifestResult = skaffLib.pluginManifestSchema.safeParse(
+        packageJson && typeof packageJson === 'object'
+          ? (packageJson as {skaff?: {manifest?: unknown}}).skaff?.manifest
+          : undefined,
+      )
+      if (!manifestResult.success) {
+        continue
       }
+
+      entries.push({
+        modulePath,
+        packageName: dependencyName,
+        manifest: manifestResult.data,
+      })
+      seenPackages.add(dependencyName)
     }
   }
 

--- a/apps/cli/test/lib/test-plugins.ts
+++ b/apps/cli/test/lib/test-plugins.ts
@@ -41,16 +41,15 @@ async function loadPluginContext(): Promise<PluginContext> {
 
 async function registerTestPlugins(): Promise<void> {
   const {registerPluginModules} = await loadPluginContext()
-  const buildPlugin = (name: string, capability: 'template' | 'cli' | 'web') => ({
-    manifest: {
-      name,
-      version: '0.0.0',
-      capabilities: [capability],
-      supportedHooks: {
-        template: [],
-        cli: [],
-        web: [],
-      },
+  const buildPlugin = (_name: string, _capability: 'template' | 'cli' | 'web') => ({})
+  const buildManifest = (name: string, capability: 'template' | 'cli' | 'web') => ({
+    name,
+    version: '0.0.0',
+    capabilities: [capability],
+    supportedHooks: {
+      template: [],
+      cli: [],
+      web: [],
     },
   })
 
@@ -58,14 +57,17 @@ async function registerTestPlugins(): Promise<void> {
     {
       packageName: '@timonteutelink/skaff-plugin-greeter',
       sandboxedExports: {default: buildPlugin('@timonteutelink/skaff-plugin-greeter', 'template')},
+      manifest: buildManifest('@timonteutelink/skaff-plugin-greeter', 'template'),
     },
     {
       packageName: '@timonteutelink/skaff-plugin-greeter-cli',
       sandboxedExports: {default: buildPlugin('@timonteutelink/skaff-plugin-greeter-cli', 'cli')},
+      manifest: buildManifest('@timonteutelink/skaff-plugin-greeter-cli', 'cli'),
     },
     {
       packageName: '@timonteutelink/skaff-plugin-greeter-web',
       sandboxedExports: {default: buildPlugin('@timonteutelink/skaff-plugin-greeter-web', 'web')},
+      manifest: buildManifest('@timonteutelink/skaff-plugin-greeter-web', 'web'),
     },
   ])
 }

--- a/apps/web/scripts/generate-plugin-registry.ts
+++ b/apps/web/scripts/generate-plugin-registry.ts
@@ -29,6 +29,7 @@ import {
   determinePluginTrustBasic,
   type PluginTrustLevel,
 } from "@timonteutelink/skaff-lib/browser";
+import { z } from "zod";
 
 interface ParsedPackageSpec {
   name: string;
@@ -65,21 +66,36 @@ function parsePackageSpec(packageSpec: string): ParsedPackageSpec {
 
 const require = createRequire(import.meta.url);
 
-interface PluginManifest {
-  name: string;
-  version: string;
-  capabilities: ("template" | "cli" | "web")[];
-  supportedHooks?: {
-    template?: string[];
-    cli?: string[];
-    web?: string[];
-  };
-  schemas?: {
-    globalConfig?: boolean;
-    input?: boolean;
-    output?: boolean;
-  };
-}
+const pluginManifestSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .regex(/^[a-zA-Z0-9-_.:@/]+$/, "Plugin names must be identifier-like."),
+  version: z
+    .string()
+    .regex(
+      /^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-.]+)?$/,
+      "Version must be semver.",
+    ),
+  capabilities: z.array(z.enum(["template", "cli", "web"])).min(1),
+  supportedHooks: z
+    .object({
+      template: z
+        .array(
+          z.enum([
+            "configureTemplateInstantiationPipeline",
+            "configureProjectCreationPipeline",
+          ]),
+        )
+        .default([]),
+      cli: z.array(z.string()).default([]),
+      web: z.array(z.string()).default([]),
+    })
+    .default({ template: [], cli: [], web: [] }),
+  requiredSettingsKeys: z.array(z.string()).optional(),
+});
+
+type PluginManifest = z.infer<typeof pluginManifestSchema>;
 
 interface PluginPackageJson {
   name: string;
@@ -88,6 +104,7 @@ interface PluginPackageJson {
     bundle?: {
       web?: string;
     };
+    manifest?: unknown;
   };
 }
 
@@ -97,6 +114,7 @@ interface DiscoveredPlugin {
   importPath: string;
   modulePath: string;
   manifestName?: string;
+  manifest: PluginManifest;
   trustLevel: PluginTrustLevel;
 }
 
@@ -106,44 +124,24 @@ const OUTPUT_FILE = resolve(OUTPUT_DIR, "generated-plugin-registry.ts");
 const MANIFEST_FILE = resolve(WEB_ROOT, "public/plugin-manifest.json");
 
 /**
- * Attempts to load and validate a plugin module to check if it's a valid Skaff plugin
- */
-async function validatePlugin(
-  packageName: string,
-): Promise<{ valid: boolean; manifest?: PluginManifest }> {
-  try {
-    // Try to require the package to get its exports
-    const modulePath = require.resolve(packageName, { paths: [WEB_ROOT] });
-    const module = await import(modulePath);
-
-    const pluginModule = module.default ?? module;
-
-    // Check if it has a manifest with web capability
-    if (
-      pluginModule?.manifest?.name &&
-      pluginModule?.manifest?.version &&
-      Array.isArray(pluginModule?.manifest?.capabilities)
-    ) {
-      const manifest = pluginModule.manifest as PluginManifest;
-      if (manifest.capabilities.includes("web")) {
-        return { valid: true, manifest };
-      }
-    }
-
-    return { valid: false };
-  } catch {
-    return { valid: false };
-  }
-}
-
-/**
  * Gets the package.json of an installed package
  */
 function getPackageJson(packageName: string): PluginPackageJson | null {
   try {
-    const pkgPath = require.resolve(`${packageName}/package.json`, {
-      paths: [WEB_ROOT],
-    });
+    const entryPath = require.resolve(packageName, { paths: [WEB_ROOT] });
+    let currentDir = dirname(entryPath);
+    let pkgPath: string | null = null;
+    while (currentDir && currentDir !== dirname(currentDir)) {
+      const candidate = resolve(currentDir, "package.json");
+      if (existsSync(candidate)) {
+        pkgPath = candidate;
+        break;
+      }
+      currentDir = dirname(currentDir);
+    }
+    if (!pkgPath) {
+      return null;
+    }
     const content = readFileSync(pkgPath, "utf-8");
     return JSON.parse(content);
   } catch {
@@ -217,14 +215,21 @@ async function discoverPlugins(): Promise<DiscoveredPlugin[]> {
       continue;
     }
 
-    const validation = await validatePlugin(packageName);
-    if (!validation.valid || !validation.manifest) {
-      console.log(`    Skipped: Not a valid Skaff web plugin`);
+    const manifestCandidate = pkgJson.skaff?.manifest;
+    const manifestResult = pluginManifestSchema.safeParse(manifestCandidate);
+    if (!manifestResult.success) {
+      console.log(`    Skipped: Missing or invalid skaff.manifest`);
+      continue;
+    }
+
+    const manifest = manifestResult.data;
+    if (!manifest.capabilities.includes("web")) {
+      console.log(`    Skipped: Missing web capability`);
       continue;
     }
 
     console.log(
-      `    Found: ${validation.manifest.name} v${validation.manifest.version}`,
+      `    Found: ${manifest.name} v${manifest.version}`,
     );
 
     const trustLevel = determinePluginTrustBasic(packageName);
@@ -237,7 +242,8 @@ async function discoverPlugins(): Promise<DiscoveredPlugin[]> {
       version: pkgJson.version,
       importPath: packageName,
       modulePath,
-      manifestName: validation.manifest.name,
+      manifestName: manifest.name,
+      manifest,
       trustLevel,
     });
   }
@@ -261,6 +267,7 @@ function generateRegistryFile(plugins: DiscoveredPlugin[]): string {
     packageName: "${p.packageName}",
     modulePath: "${p.modulePath}",
     version: "${p.version}",
+    manifest: ${JSON.stringify(p.manifest, null, 2).replace(/\n/g, "\n    ")},
     trustLevel: "${p.trustLevel}",
   }`,
     )
@@ -273,6 +280,7 @@ function generateRegistryFile(plugins: DiscoveredPlugin[]): string {
     name: "${p.manifestName ?? p.packageName}",
     packageName: "${p.packageName}",
     version: "${p.version}",
+    manifest: ${JSON.stringify(p.manifest, null, 2).replace(/\n/g, "\n    ")},
     trustLevel: "${p.trustLevel}",
   }`,
     )
@@ -289,7 +297,7 @@ function generateRegistryFile(plugins: DiscoveredPlugin[]): string {
  * Generated: ${new Date().toISOString()}
  */
 
-import type { PluginTrustLevel } from "@timonteutelink/skaff-lib";
+import type { PluginManifest, PluginTrustLevel } from "@timonteutelink/skaff-lib";
 
 ${imports}
 
@@ -298,6 +306,7 @@ export interface InstalledPluginEntry {
   packageName: string;
   modulePath: string;
   version: string;
+  manifest: PluginManifest;
   trustLevel: PluginTrustLevel;
 }
 
@@ -305,6 +314,7 @@ export interface PluginManifestEntry {
   name: string;
   packageName: string;
   version: string;
+  manifest: PluginManifest;
   trustLevel: PluginTrustLevel;
 }
 
@@ -369,6 +379,7 @@ function generateManifestJson(plugins: DiscoveredPlugin[]): string {
     packageName: p.packageName,
     version: p.version,
     trustLevel: p.trustLevel,
+    manifest: p.manifest,
   }));
 
   return JSON.stringify(manifest, null, 2);

--- a/apps/web/src/lib/plugins/register-plugins.ts
+++ b/apps/web/src/lib/plugins/register-plugins.ts
@@ -21,6 +21,7 @@ export function ensureWebPluginsRegistered(): void {
     moduleExports: entry.module,
     modulePath: entry.modulePath,
     packageName: entry.packageName,
+    manifest: entry.manifest,
   }));
 
   if (entries.length > 0) {

--- a/apps/web/src/lib/plugins/web-stage-loader.ts
+++ b/apps/web/src/lib/plugins/web-stage-loader.ts
@@ -150,10 +150,21 @@ function pickEntrypoint(
 
 function coerceToPluginModule(entry: unknown): SkaffPluginModule | null {
   if (!entry || typeof entry !== "object") return null;
-  if ("manifest" in (entry as Record<string, unknown>)) {
-    return entry as SkaffPluginModule;
-  }
-  return null;
+  return entry as SkaffPluginModule;
+}
+
+function resolveInstalledManifest(
+  moduleSpecifier: string,
+): PluginManifestEntry | undefined {
+  const pluginName = extractPluginName(moduleSpecifier);
+  return (
+    PLUGIN_MANIFEST.find(
+      (entry) =>
+        entry.name === pluginName ||
+        entry.packageName === moduleSpecifier ||
+        entry.packageName === pluginName,
+    ) ?? undefined
+  );
 }
 
 /**
@@ -327,7 +338,8 @@ export async function loadWebTemplateStages(
     if (!web?.templateStages?.length) continue;
 
     // Get the actual plugin name from manifest
-    const manifestName = pluginModule.manifest?.name || pluginName;
+    const manifestName =
+      resolveInstalledManifest(reference.module)?.name ?? pluginName;
 
     for (const stage of web.templateStages) {
       // Use createPluginStageEntry for automatic state key namespacing
@@ -366,13 +378,13 @@ export async function loadWebTemplatePluginRequirements(
     if (!pluginModule) {
       continue;
     }
-    const requiredSettingsKeys = (
-      pluginModule.manifest as { requiredSettingsKeys?: string[] } | undefined
-    )?.requiredSettingsKeys;
+    const requiredSettingsKeys =
+      resolveInstalledManifest(reference.module)?.manifest.requiredSettingsKeys;
     if (!requiredSettingsKeys?.length) continue;
 
     requirements.push({
-      pluginName: pluginModule.manifest.name ?? pluginName,
+      pluginName:
+        resolveInstalledManifest(reference.module)?.name ?? pluginName,
       requiredSettingsKeys,
     });
   }

--- a/examples/plugins/plugin-greeter-cli/package.json
+++ b/examples/plugins/plugin-greeter-cli/package.json
@@ -23,6 +23,20 @@
     "@timonteutelink/skaff-plugin-greeter": "workspace:*",
     "@timonteutelink/skaff-plugin-greeter-types": "workspace:*"
   },
+  "skaff": {
+    "manifest": {
+      "name": "greeter",
+      "version": "0.0.1",
+      "capabilities": [
+        "cli"
+      ],
+      "supportedHooks": {
+        "template": [],
+        "cli": [],
+        "web": []
+      }
+    }
+  },
   "devDependencies": {
     "@inquirer/prompts": "^5.3.8",
     "typescript": "5.9.3"

--- a/examples/plugins/plugin-greeter-cli/src/index.ts
+++ b/examples/plugins/plugin-greeter-cli/src/index.ts
@@ -3,7 +3,6 @@ import type {
   CliTemplateStage,
   PluginCliCommand,
 } from "@timonteutelink/skaff-lib";
-import { GREETER_PLUGIN_NAME } from "@timonteutelink/skaff-plugin-greeter-types";
 
 type GreeterStageState = { disabled?: boolean; message?: string };
 type InquirerPrompts = typeof import("@inquirer/prompts");
@@ -89,12 +88,6 @@ const greeterCliContribution: CliPluginContribution<InquirerPrompts> = {
 };
 
 const greeterCliPlugin = {
-  manifest: {
-    name: GREETER_PLUGIN_NAME,
-    version: "0.0.0",
-    capabilities: ["cli"],
-    supportedHooks: { template: [], cli: [], web: [] },
-  },
   cli: greeterCliContribution,
 };
 

--- a/examples/plugins/plugin-greeter-web/package.json
+++ b/examples/plugins/plugin-greeter-web/package.json
@@ -24,6 +24,20 @@
     "@timonteutelink/skaff-plugin-greeter-types": "workspace:*",
     "react": "19.2.0"
   },
+  "skaff": {
+    "manifest": {
+      "name": "greeter",
+      "version": "0.0.1",
+      "capabilities": [
+        "web"
+      ],
+      "supportedHooks": {
+        "template": [],
+        "cli": [],
+        "web": []
+      }
+    }
+  },
   "peerDependencies": {
     "@timonteutelink/skaff-lib": ">=0.0.56",
     "react": "^19.2.0"

--- a/examples/plugins/plugin-greeter-web/src/index.tsx
+++ b/examples/plugins/plugin-greeter-web/src/index.tsx
@@ -6,7 +6,6 @@ import type {
   WebTemplateStage,
 } from "@timonteutelink/skaff-lib";
 import React, { useState } from "react";
-import { GREETER_PLUGIN_NAME } from "@timonteutelink/skaff-plugin-greeter-types";
 
 type GreeterStageState = { disabled?: boolean; message?: string };
 
@@ -144,12 +143,6 @@ const greeterWebContribution: WebPluginContribution = {
 };
 
 const greeterWebPlugin = {
-  manifest: {
-    name: GREETER_PLUGIN_NAME,
-    version: "0.0.0",
-    capabilities: ["web"],
-    supportedHooks: { template: [], cli: [], web: [] },
-  },
   web: greeterWebContribution,
 };
 

--- a/examples/plugins/plugin-greeter/package.json
+++ b/examples/plugins/plugin-greeter/package.json
@@ -24,6 +24,20 @@
     "@timonteutelink/template-types-lib": "workspace:*"
   },
   "skaff": {
+    "manifest": {
+      "name": "greeter",
+      "version": "0.0.1",
+      "capabilities": [
+        "template"
+      ],
+      "supportedHooks": {
+        "template": [
+          "configureTemplateInstantiationPipeline"
+        ],
+        "cli": [],
+        "web": []
+      }
+    },
     "bundle": {
       "cli": "@timonteutelink/skaff-plugin-greeter-cli",
       "web": "@timonteutelink/skaff-plugin-greeter-web"

--- a/examples/plugins/plugin-greeter/src/index.ts
+++ b/examples/plugins/plugin-greeter/src/index.ts
@@ -110,16 +110,6 @@ const greeterLifecycle: PluginLifecycle = {
 };
 
 const greeterPlugin: SkaffPluginModule = {
-  manifest: {
-    name: GREETER_PLUGIN_NAME,
-    version: "0.0.0",
-    capabilities: ["template"],
-    supportedHooks: {
-      template: ["configureTemplateInstantiationPipeline"],
-      cli: [],
-      web: [],
-    },
-  },
   lifecycle: greeterLifecycle,
   template: createGreeterTemplatePlugin,
 };

--- a/packages/skaff-lib/src/core/plugins/plugin-compatibility.ts
+++ b/packages/skaff-lib/src/core/plugins/plugin-compatibility.ts
@@ -307,7 +307,7 @@ export function createPluginCompatibilityValidators(
       return { data: undefined };
     }
 
-    const manifestName = pluginModule.manifest?.name ?? pluginName;
+    const manifestName = installedPlugin?.name ?? pluginName;
     const rawSettings = options.pluginSettings?.[manifestName];
     const parsed = pluginModule.globalConfigSchema.safeParse(rawSettings ?? {});
 
@@ -358,7 +358,7 @@ export function createPluginCompatibilityValidators(
       return { data: undefined };
     }
 
-    const manifestName = pluginModule.manifest?.name ?? pluginName;
+    const manifestName = installedPlugin?.name ?? pluginName;
     return {
       data: {
         module: pluginConfig.module,

--- a/packages/skaff-lib/src/core/plugins/plugin-loader.ts
+++ b/packages/skaff-lib/src/core/plugins/plugin-loader.ts
@@ -90,6 +90,7 @@ export interface RegisteredPluginModule {
   modulePath?: string;
   sandboxedExports?: unknown;
   packageName?: string;
+  manifest: PluginManifest;
 }
 
 const registeredPlugins = new Map<string, RegisteredPluginModule>();
@@ -101,6 +102,7 @@ export function registerPluginModules(entries: RegisteredPluginModule[]): void {
       registeredPlugins.set(packageName, entry);
       registeredPlugins.set(extractPluginName(packageName), entry);
     }
+    registeredPlugins.set(entry.manifest.name, entry);
   }
 }
 
@@ -110,10 +112,7 @@ export function clearRegisteredPluginModules(): void {
 
 function coerceToPluginModule(entry: unknown): SkaffPluginModule | null {
   if (!entry || typeof entry !== "object") return null;
-  if ("manifest" in (entry as Record<string, unknown>)) {
-    return entry as SkaffPluginModule;
-  }
-  return null;
+  return entry as SkaffPluginModule;
 }
 
 export async function resolveRegisteredPluginModule(
@@ -136,7 +135,7 @@ export async function resolveRegisteredPluginModule(
   const pluginModule = coerceToPluginModule(entry);
   if (!pluginModule) {
     return {
-      error: `Plugin ${reference.module} did not export a usable entry point with a manifest`,
+      error: `Plugin ${reference.module} did not export a usable entry point`,
     };
   }
 
@@ -314,6 +313,7 @@ async function buildWebPlugin(
 
 function buildSettingsInputTransform(
   module: SkaffPluginModule,
+  pluginName: string,
   context: SettingsInputTransformContext,
 ): Result<BoundSettingsInputTransform | undefined> {
   const entrypoint = module.settingsInputTransform;
@@ -321,7 +321,7 @@ function buildSettingsInputTransform(
 
   if (typeof entrypoint !== "function") {
     return {
-      error: `Plugin ${module.manifest.name} settingsInputTransform must be a function`,
+      error: `Plugin ${pluginName} settingsInputTransform must be a function`,
     };
   }
 
@@ -338,10 +338,7 @@ function buildSettingsInputTransform(
 }
 
 
-function validateManifest(
-  manifest: PluginManifest,
-  module: SkaffPluginModule,
-): Result<PluginManifest> {
+function validateManifest(manifest: PluginManifest): Result<PluginManifest> {
   const parsed = pluginManifestSchema.safeParse(manifest);
 
   if (!parsed.success) {
@@ -429,6 +426,12 @@ export async function loadPluginsForTemplate(
       return { error: moduleResult.error };
     }
 
+    const manifestResult = validateManifest(moduleResult.data.manifest);
+
+    if ("error" in manifestResult) {
+      return manifestResult;
+    }
+
     const exportsResult = await resolveSandboxedPluginExports(
       moduleResult.data,
       reference,
@@ -441,17 +444,8 @@ export async function loadPluginsForTemplate(
     const pluginModule = coerceToPluginModule(entry);
     if (!pluginModule) {
       return {
-        error: `Plugin ${reference.module} did not export a usable entry point with a manifest`,
+        error: `Plugin ${reference.module} did not export a usable entry point`,
       };
-    }
-
-    const manifestResult = validateManifest(
-      pluginModule.manifest,
-      pluginModule,
-    );
-
-    if ("error" in manifestResult) {
-      return manifestResult;
     }
 
     const manifest = manifestResult.data;
@@ -495,6 +489,7 @@ export async function loadPluginsForTemplate(
 
     const settingsInputTransform = buildSettingsInputTransform(
       pluginModule,
+      pluginName,
       settingsTransformContext,
     );
     if ("error" in settingsInputTransform) {

--- a/packages/skaff-lib/src/core/plugins/plugin-types.ts
+++ b/packages/skaff-lib/src/core/plugins/plugin-types.ts
@@ -351,6 +351,7 @@ export const pluginManifestSchema = z.object({
       web: z.array(z.string()).default([]),
     })
     .default({ template: [], cli: [], web: [] }),
+  requiredSettingsKeys: z.array(z.string()).optional(),
 });
 
 export type PluginManifest = z.infer<typeof pluginManifestSchema>;
@@ -735,25 +736,16 @@ export interface CliTemplateStage<
  * The main plugin module interface.
  *
  * This is what a plugin package must export as its default or named export.
- * It defines the plugin's manifest, optional global configuration schema,
- * and entrypoints.
+ * It defines the plugin's optional configuration schemas and entrypoints.
  *
  * @example
  * ```typescript
  * const myPlugin: SkaffPluginModule = {
- *   manifest: {
- *     name: "my-plugin",
- *     version: "1.0.0",
- *     capabilities: ["template"],
- *   },
  *   template: (input) => ({ ... }),
  * };
  * ```
  */
 export interface SkaffPluginModule {
-  /** Plugin manifest with metadata and capability declarations */
-  manifest: PluginManifest;
-
   /**
    * Optional lifecycle hooks for the plugin.
    * These are called at specific points during plugin and generation operations.
@@ -804,10 +796,10 @@ export interface LoadedTemplatePlugin {
   /** The loaded plugin module */
   module: SkaffPluginModule;
 
-  /** Plugin name from manifest */
+  /** Plugin name from manifest metadata */
   name: string;
 
-  /** Plugin version from manifest */
+  /** Plugin version from manifest metadata */
   version: string;
 
   /** Resolved global configuration for this plugin */

--- a/packages/skaff-lib/tests/lib/integration-fixtures.ts
+++ b/packages/skaff-lib/tests/lib/integration-fixtures.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { registerPluginModules } from "../../src/core/plugins";
+import type { PluginManifest } from "../../src/core/plugins";
 import greeterPluginModule from "../../../../examples/plugins/plugin-greeter/src/index";
 import greeterCliPluginModule from "../../../../examples/plugins/plugin-greeter-cli/src/index";
 import greeterWebPluginModule from "../../../../examples/plugins/plugin-greeter-web/src/index";
@@ -124,19 +125,27 @@ export async function setupIntegrationTestEnvironment(
 export function registerGreeterPlugins(options?: {
   includeSandboxedExports?: boolean;
 }): void {
-  const greeterCliModule = {
-    ...greeterCliPluginModule,
-    manifest: {
-      ...greeterCliPluginModule.manifest,
-      name: "greeter-cli",
+  const greeterManifest: PluginManifest = {
+    name: "greeter",
+    version: "0.0.0",
+    capabilities: ["template"],
+    supportedHooks: {
+      template: ["configureTemplateInstantiationPipeline"],
+      cli: [],
+      web: [],
     },
   };
-  const greeterWebModule = {
-    ...greeterWebPluginModule,
-    manifest: {
-      ...greeterWebPluginModule.manifest,
-      name: "greeter-web",
-    },
+  const greeterCliManifest: PluginManifest = {
+    name: "greeter-cli",
+    version: "0.0.0",
+    capabilities: ["cli"],
+    supportedHooks: { template: [], cli: [], web: [] },
+  };
+  const greeterWebManifest: PluginManifest = {
+    name: "greeter-web",
+    version: "0.0.0",
+    capabilities: ["web"],
+    supportedHooks: { template: [], cli: [], web: [] },
   };
 
   const includeSandboxedExports = options?.includeSandboxedExports ?? false;
@@ -155,22 +164,25 @@ export function registerGreeterPlugins(options?: {
         "../../../../examples/plugins/plugin-greeter/src/index.ts",
       ),
       packageName: "@timonteutelink/skaff-plugin-greeter",
+      manifest: greeterManifest,
     }),
     withSandboxedExports({
-      moduleExports: greeterCliModule,
+      moduleExports: greeterCliPluginModule,
       modulePath: path.resolve(
         __dirname,
         "../../../../examples/plugins/plugin-greeter-cli/src/index.ts",
       ),
       packageName: "@timonteutelink/skaff-plugin-greeter-cli",
+      manifest: greeterCliManifest,
     }),
     withSandboxedExports({
-      moduleExports: greeterWebModule,
+      moduleExports: greeterWebPluginModule,
       modulePath: path.resolve(
         __dirname,
         "../../../../examples/plugins/plugin-greeter-web/src/index.tsx",
       ),
       packageName: "@timonteutelink/skaff-plugin-greeter-web",
+      manifest: greeterWebManifest,
     }),
   ]);
 }

--- a/packages/skaff-lib/tests/plugin-loader.test.ts
+++ b/packages/skaff-lib/tests/plugin-loader.test.ts
@@ -13,6 +13,7 @@ import {
   loadPluginsForTemplate,
   registerPluginModules,
 } from "../src/core/plugins";
+import type { PluginManifest } from "../src/core/plugins";
 import { PipelineBuilder } from "../src/core/generation/pipeline/pipeline-runner";
 import { createTempDir, writeTemplateFileTree } from "./lib";
 
@@ -109,6 +110,7 @@ describeIfSES("plugin loading", () => {
   async function registerPluginModule(
     pluginPath: string,
     packageName: string,
+    manifest: PluginManifest,
   ) {
     const moduleNamespace = await import(pathToFileURL(pluginPath).href);
     registerPluginModules([
@@ -116,6 +118,7 @@ describeIfSES("plugin loading", () => {
         moduleExports: moduleNamespace,
         modulePath: pluginPath,
         packageName,
+        manifest,
       },
     ]);
   }
@@ -129,16 +132,20 @@ describeIfSES("plugin loading", () => {
       await createTemplateWorkspace();
 
     const pluginPath = path.join(baseDir, "plugin.cjs");
+    const manifest: PluginManifest = {
+      name: "test-plugin",
+      version: "0.0.0",
+      capabilities: ["template"],
+      supportedHooks: {
+        template: ["configureTemplateInstantiationPipeline"],
+        cli: [],
+        web: [],
+      },
+    };
     await fs.writeFile(
       pluginPath,
       [
         "module.exports = {",
-        "  manifest: {",
-        "    name: 'test-plugin',",
-        "    version: '0.0.0',",
-        "    capabilities: ['template'],",
-        "    supportedHooks: { template: ['configureTemplateInstantiationPipeline'], cli: [], web: [] },",
-        "  },",
         "  template: ({ options }) => ({",
         "    captured: options,",
         "    configureTemplateInstantiationPipeline(builder) {",
@@ -156,7 +163,7 @@ describeIfSES("plugin loading", () => {
     );
 
     const packageName = "test-plugin-package";
-    await registerPluginModule(pluginPath, packageName);
+    await registerPluginModule(pluginPath, packageName, manifest);
 
     template.config.plugins = [
       { module: packageName, options: { flag: true } },
@@ -192,16 +199,16 @@ describeIfSES("plugin loading", () => {
       await createTemplateWorkspace();
 
     const pluginPath = path.join(baseDir, "path-guard-plugin.cjs");
+    const manifest: PluginManifest = {
+      name: "path-guard-plugin",
+      version: "0.0.0",
+      capabilities: ["template"],
+      supportedHooks: { template: [], cli: [], web: [] },
+    };
     await fs.writeFile(
       pluginPath,
       [
         "module.exports = {",
-        "  manifest: {",
-        "    name: 'path-guard-plugin',",
-        "    version: '0.0.0',",
-        "    capabilities: ['template'],",
-        "    supportedHooks: { template: [], cli: [], web: [] },",
-        "  },",
         "  template: ({ template, projectContext }) => ({",
         "    captured: {",
         "      hasAbsoluteDir: Boolean(template.absoluteDir),",
@@ -216,7 +223,7 @@ describeIfSES("plugin loading", () => {
     );
 
     const packageName = "path-guard-plugin-package";
-    await registerPluginModule(pluginPath, packageName);
+    await registerPluginModule(pluginPath, packageName, manifest);
 
     template.config.plugins = [{ module: packageName }];
 
@@ -242,16 +249,20 @@ describeIfSES("plugin loading", () => {
       await createTemplateWorkspace();
 
     const pluginPath = path.join(baseDir, "plugin.cjs");
+    const manifest: PluginManifest = {
+      name: "test-plugin",
+      version: "0.0.0",
+      capabilities: ["template", "cli", "web"],
+      supportedHooks: {
+        template: ["configureTemplateInstantiationPipeline"],
+        cli: [],
+        web: [],
+      },
+    };
     await fs.writeFile(
       pluginPath,
       [
         "module.exports = {",
-        "  manifest: {",
-        "    name: 'test-plugin',",
-        "    version: '0.0.0',",
-        "    capabilities: ['template', 'cli', 'web'],",
-        "    supportedHooks: { template: ['configureTemplateInstantiationPipeline'], cli: [], web: [] },",
-        "  },",
         "  template: {",
         "    configureTemplateInstantiationPipeline(builder) {",
         "      builder.add({",
@@ -275,7 +286,7 @@ describeIfSES("plugin loading", () => {
     );
 
     const packageName = "test-plugin-package";
-    await registerPluginModule(pluginPath, packageName);
+    await registerPluginModule(pluginPath, packageName, manifest);
 
     template.config.plugins = [{ module: packageName }];
 
@@ -308,16 +319,16 @@ describeIfSES("plugin loading", () => {
       await createTemplateWorkspace();
 
     const pluginPath = path.join(baseDir, "settings-plugin.cjs");
+    const manifest: PluginManifest = {
+      name: "settings-plugin",
+      version: "0.0.0",
+      capabilities: ["template"],
+      supportedHooks: { template: [], cli: [], web: [] },
+    };
     await fs.writeFile(
       pluginPath,
       [
         "module.exports = {",
-        "  manifest: {",
-        "    name: 'settings-plugin',",
-        "    version: '0.0.0',",
-        "    capabilities: ['template'],",
-        "    supportedHooks: { template: [], cli: [], web: [] },",
-        "  },",
         "  settingsInputTransform(input, context) {",
         "    return {",
         "      received: input,",
@@ -336,7 +347,7 @@ describeIfSES("plugin loading", () => {
     );
 
     const packageName = "settings-plugin-package";
-    await registerPluginModule(pluginPath, packageName);
+    await registerPluginModule(pluginPath, packageName, manifest);
 
     template.config.plugins = [{ module: packageName, options: { flag: true } }];
 
@@ -368,16 +379,16 @@ describeIfSES("plugin loading", () => {
       await createTemplateWorkspace();
 
     const pluginPath = path.join(baseDir, "unsafe-plugin.cjs");
+    const manifest: PluginManifest = {
+      name: "unsafe-plugin",
+      version: "0.0.1",
+      capabilities: ["template"],
+      supportedHooks: { template: [], cli: [], web: [] },
+    };
     await fs.writeFile(
       pluginPath,
       [
         "module.exports = {",
-        "  manifest: {",
-        "    name: 'unsafe-plugin',",
-        "    version: '0.0.1',",
-        "    capabilities: ['template'],",
-        "    supportedHooks: { template: [], cli: [], web: [] },",
-        "  },",
         "  template: {},",
         "  globalConfigSchema: require('fs'),",
         "};",
@@ -386,7 +397,7 @@ describeIfSES("plugin loading", () => {
     );
 
     const packageName = "unsafe-plugin-package";
-    await registerPluginModule(pluginPath, packageName);
+    await registerPluginModule(pluginPath, packageName, manifest);
 
     template.config.plugins = [{ module: packageName }];
 

--- a/packages/skaff-plugin-erd-web/package.json
+++ b/packages/skaff-plugin-erd-web/package.json
@@ -23,6 +23,20 @@
     "@timonteutelink/skaff-plugin-erd-types": "workspace:*",
     "react": "19.2.0"
   },
+  "skaff": {
+    "manifest": {
+      "name": "erd",
+      "version": "0.0.1",
+      "capabilities": [
+        "web"
+      ],
+      "supportedHooks": {
+        "template": [],
+        "cli": [],
+        "web": []
+      }
+    }
+  },
   "devDependencies": {
     "typescript": "5.9.3"
   }

--- a/packages/skaff-plugin-erd-web/src/index.tsx
+++ b/packages/skaff-plugin-erd-web/src/index.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import "@dineug/erd-editor";
 import type { ErdEditorElement } from "@dineug/erd-editor";
 import type {
   TemplateStageRenderProps,
@@ -41,6 +40,10 @@ function ErdStage({
 }: ErdStageProps) {
   const editorRef = React.useRef<ErdEditorElement | null>(null);
   const hasInitializedRef = React.useRef(false);
+
+  React.useEffect(() => {
+    void import("@dineug/erd-editor");
+  }, []);
 
   const settingsInput = React.useMemo(() => {
     if (settingsDraft && Object.keys(settingsDraft).length > 0) {
@@ -161,12 +164,6 @@ const createErdWebContribution: WebPluginEntrypoint = (input) => {
 };
 
 const erdWebPlugin = {
-  manifest: {
-    name: "erd",
-    version: "0.0.0",
-    capabilities: ["web"],
-    supportedHooks: { template: [], cli: [], web: [] },
-  },
   web: createErdWebContribution,
 };
 

--- a/packages/skaff-plugin-erd/package.json
+++ b/packages/skaff-plugin-erd/package.json
@@ -25,6 +25,18 @@
     "zod": "^4.1.12"
   },
   "skaff": {
+    "manifest": {
+      "name": "erd",
+      "version": "0.0.1",
+      "capabilities": [
+        "template"
+      ],
+      "supportedHooks": {
+        "template": [],
+        "cli": [],
+        "web": []
+      }
+    },
     "bundle": {
       "web": "@timonteutelink/skaff-plugin-erd-web"
     }

--- a/packages/skaff-plugin-erd/src/index.ts
+++ b/packages/skaff-plugin-erd/src/index.ts
@@ -16,11 +16,11 @@ import { erdSchemaZod } from "@timonteutelink/skaff-plugin-erd-types";
 const erdSchemaAny = erdSchemaZod as unknown as z.ZodTypeAny;
 
 const erdMappersSchema = z.object({
-  toErd: z.function().args(z.unknown()).returns(erdSchemaAny),
+  toErd: z.function().input([z.unknown()]).output(erdSchemaAny),
   fromErd: z
     .function()
-    .args(erdSchemaAny)
-    .returns(z.record(z.string(), z.unknown())),
+    .input([erdSchemaAny])
+    .output(z.record(z.string(), z.unknown())),
 });
 
 const erdPluginOptionsSchema = z.object({
@@ -75,12 +75,6 @@ const createErdTemplatePlugin: TemplatePluginEntrypoint = (input) => {
 };
 
 const erdPlugin: SkaffPluginModule = {
-  manifest: {
-    name: "erd",
-    version: "0.0.0",
-    capabilities: ["template"],
-    supportedHooks: { template: [], cli: [], web: [] },
-  },
   template: createErdTemplatePlugin,
 };
 


### PR DESCRIPTION
### Motivation

- Prevent the web plugin registry generator from importing runtime SES initialization via `skaff-lib` to avoid SES/lockdown errors during build.
- Treat plugin manifest metadata as static package metadata so discovery does not require importing plugin modules at build or discovery time.
- Ensure web-capable plugins (notably the ERD editor) can be discovered and bundled without pulling client-only code into SSR/build steps.
- Make plugin registration accept and use manifest metadata read from `package.json` rather than requiring runtime `manifest` exports.

### Description

- Inlined the plugin manifest Zod schema into `apps/web/scripts/generate-plugin-registry.ts` and updated the generator to read and validate `skaff.manifest` from `package.json` instead of importing plugin modules at build time. 
- Updated discovery/registration flow to read manifests from package.json: added `readPackageJson`/`resolvePackageJsonPath` helpers in `apps/cli/src/utils/plugin-manager.ts`, changed CLI plugin discovery/registration to use package manifests, and updated `registerPluginModules` call sites to pass `manifest` entries. 
- Updated plugin types and loader to stop requiring `manifest` on module exports by moving manifest into registration entries and validating manifests via `pluginManifestSchema`; updated web registration (`apps/web/src/lib/plugins/register-plugins.ts`) and registry generation to embed manifest metadata. 
- Fixed ERD web plugin to avoid immediate top-level import of `@dineug/erd-editor` and instead lazy-load it in a `useEffect`, added `skaff.manifest` entries to example and plugin `package.json` files, and added a `build-erd-plugins` Makefile target (included in `build-all`).

### Testing

- Ran `make cr` (clean + install) which completed successfully.
- Ran `SKAFF_PLUGINS="@timonteutelink/skaff-plugin-erd-web" make ba` and the full build (including plugin registry generation and Next.js build) completed successfully.
- Started the web server with `make rw` and verified pages responded with HTTP `200` using `curl` for `/`, `/templates`, and `/templates/template`.
- Ran unit/integration tests with `cd packages/skaff-lib && bun run test` and all automated tests passed (`31` suites, `216` tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f0d8e1d308325bf185de01f339dbe)