### PR TITLE
Remove test-time plugin sandbox stubs from Jest setup

### DIFF
--- a/packages/skaff-lib/tests/setup-env.ts
+++ b/packages/skaff-lib/tests/setup-env.ts
@@ -6,21 +6,7 @@
  * Jest's mocking system which uses Node.js domains.
  */
 import { markHardenedEnvironmentForTesting } from "../src/core/infra/hardened-sandbox";
-import { registerPluginSandboxLibraries } from "../src/core/infra/sandbox-endowments";
 import { initializeTestCleanup } from "./lib";
 
 markHardenedEnvironmentForTesting();
 initializeTestCleanup();
-
-registerPluginSandboxLibraries({
-  react: {
-    useState: (initial: unknown) => [initial, () => undefined],
-    createElement: () => null,
-    Fragment: "fragment",
-  },
-  "react/jsx-runtime": {
-    jsx: () => null,
-    jsxs: () => null,
-    Fragment: "fragment",
-  },
-});


### PR DESCRIPTION
### Motivation
- The Jest test setup previously injected environment-specific plugin stubs (small React/JXS shims) via `registerPluginSandboxLibraries`, but those are not needed for the library-level tests and couple the test harness to UI-specific endowments. 
- The sandboxing behavior for runtime/plugin code is still required, but full SES `lockdown()` conflicts with Jest, so a test-friendly polyfill must remain. 
- Removing the ad-hoc plugin stubs makes tests and core infra less coupled to web/CLI-specific runtime shims. 
- This change aligns test setup with the principle that plugin sandbox libraries should be registered by the environment that needs them (CLI/Web) rather than globally in library tests. 

### Description
- Removed the `registerPluginSandboxLibraries` import and the hard-coded React / `react/jsx-runtime` stubs from `packages/skaff-lib/tests/setup-env.ts`. 
- Kept `markHardenedEnvironmentForTesting()` in `packages/skaff-lib/tests/setup-env.ts` to provide the test-safe harden/polyfill used in Jest instead of calling SES `lockdown()`. 
- No other API or production code was modified; this is strictly a test setup cleanup. 
- The change is limited to `packages/skaff-lib/tests/setup-env.ts` (14 deletions). 

### Testing
- Ran the full skaff-lib test suite with `cd packages/skaff-lib && bun run test`, which builds prerequisites and executes Jest. 
- Test run completed successfully: `31` test suites and `216` tests passed. 
- The changes were validated by the integration and unit tests that exercise sandbox behavior (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f10cb16d08325966ac5cfdcb0bf45)