### PR TITLE
Add CLI plugin input sources to settings transforms

### DIFF
--- a/apps/cli/src/commands/project/new.ts
+++ b/apps/cli/src/commands/project/new.ts
@@ -1,5 +1,6 @@
 import {Args, Flags} from '@oclif/core'
 import * as skaffLib from '@timonteutelink/skaff-lib'
+import {createReadonlyProjectContext} from '@timonteutelink/template-types-lib'
 
 import Base from '../../base-command.js'
 import {viewParsedDiffWithGit} from '../../utils/diff-utils.js'
@@ -8,6 +9,7 @@ import {
   formatPluginCompatibilityForCli,
   formatTemplateSettingsWarningsForCli,
 } from '../../utils/plugin-manager.js'
+import {resolveCliPluginInputs} from '../../utils/plugin-inputs.js'
 import {readUserTemplateSettings} from '../../utils/template-utils.js'
 
 export default class InstantiationProjectNew extends Base {
@@ -21,6 +23,11 @@ export default class InstantiationProjectNew extends Base {
     settings: Flags.string({
       char: 's',
       description: 'Inline JSON or path to JSON file with template settings. If omitted, settings are prompted.',
+    }),
+    'plugin-input': Flags.string({
+      description:
+        'Plugin input in the form "<plugin>:<input>=<value>" (repeatable). Prefix value with "@" to load JSON from a file.',
+      multiple: true,
     }),
     repo: Flags.string({description: 'Git repository URL or path to load before instantiation'}),
     branch: Flags.string({description: 'Branch to checkout when loading repo (optional)'}),
@@ -46,18 +53,18 @@ export default class InstantiationProjectNew extends Base {
       }
     }
 
+    const templateResult = await skaffLib.getTemplate(args.templateName)
+    if ('error' in templateResult) {
+      this.error(templateResult.error, {exit: 1})
+    }
+
+    const templateData = templateResult.data
+    if (!templateData) {
+      this.error(`Template "${args.templateName}" not found.`, {exit: 1})
+    }
+
     // Check plugin compatibility before proceeding
     if (!flags['skip-plugin-check']) {
-      const templateResult = await skaffLib.getTemplate(args.templateName)
-      if ('error' in templateResult) {
-        this.error(templateResult.error, {exit: 1})
-      }
-
-      const templateData = templateResult.data
-      if (!templateData) {
-        this.error(`Template "${args.templateName}" not found.`, {exit: 1})
-      }
-
       const plugins = templateData.template.config.plugins
       if (plugins && plugins.length > 0) {
         const compatibility = await checkTemplatePluginsCompatibility(
@@ -81,7 +88,22 @@ export default class InstantiationProjectNew extends Base {
       }
     }
 
-    const settings = await readUserTemplateSettings(args.templateName, args.templateName, flags.settings)
+    const projectContext = createReadonlyProjectContext({
+      projectRepositoryName: args.projectRepositoryName,
+      projectAuthor: '',
+      rootTemplateName: args.templateName,
+    })
+
+    const pluginsResult = await skaffLib.loadPluginsForTemplate(templateData.template, projectContext)
+    if ('error' in pluginsResult) {
+      this.error(pluginsResult.error, {exit: 1})
+    }
+
+    const pluginInputs = await resolveCliPluginInputs(pluginsResult.data, flags['plugin-input'])
+
+    const settings = await readUserTemplateSettings(args.templateName, args.templateName, flags.settings, undefined, {
+      pluginInputs,
+    })
 
     const res = await skaffLib.generateNewProject(args.projectRepositoryName, args.templateName, process.cwd(), settings, {
       git: true,

--- a/apps/cli/src/utils/plugin-inputs.ts
+++ b/apps/cli/src/utils/plugin-inputs.ts
@@ -1,0 +1,163 @@
+import fs from 'node:fs/promises'
+
+import type {
+  CliPluginInputSource,
+  LoadedTemplatePlugin,
+  PluginInputsByPlugin,
+  PluginInputValues,
+} from '@timonteutelink/skaff-lib'
+
+const PLUGIN_INPUT_SEPARATOR = ':'
+
+interface ParsedInputArgument {
+  pluginName?: string
+  inputId: string
+  rawValue: string
+}
+
+function parsePluginInputArgument(value: string): ParsedInputArgument {
+  const separatorIndex = value.indexOf('=')
+  if (separatorIndex === -1) {
+    throw new Error(`Invalid plugin input "${value}". Expected "<plugin>:<input>=<value>".`)
+  }
+
+  const key = value.slice(0, separatorIndex).trim()
+  const rawValue = value.slice(separatorIndex + 1)
+
+  if (!key) {
+    throw new Error(`Invalid plugin input "${value}". Missing input key.`)
+  }
+
+  const pluginSeparatorIndex = key.indexOf(PLUGIN_INPUT_SEPARATOR)
+  if (pluginSeparatorIndex === -1) {
+    return {inputId: key, rawValue}
+  }
+
+  const pluginName = key.slice(0, pluginSeparatorIndex).trim()
+  const inputId = key.slice(pluginSeparatorIndex + 1).trim()
+
+  if (!pluginName || !inputId) {
+    throw new Error(`Invalid plugin input "${value}". Expected "<plugin>:<input>=<value>".`)
+  }
+
+  return {pluginName, inputId, rawValue}
+}
+
+async function parsePluginInputValue(rawValue: string): Promise<unknown> {
+  if (rawValue.startsWith('@')) {
+    const filePath = rawValue.slice(1)
+    const fileContents = await fs.readFile(filePath, 'utf8')
+    return JSON.parse(fileContents)
+  }
+
+  try {
+    return JSON.parse(rawValue)
+  } catch {
+    return rawValue
+  }
+}
+
+function buildInputSourceIndex(
+  plugins: LoadedTemplatePlugin[],
+): {
+  sourcesByPlugin: Map<string, Map<string, CliPluginInputSource>>
+  aliases: Map<string, string>
+  inputIdIndex: Map<string, string[]>
+} {
+  const sourcesByPlugin = new Map<string, Map<string, CliPluginInputSource>>()
+  const aliases = new Map<string, string>()
+  const inputIdIndex = new Map<string, string[]>()
+
+  for (const plugin of plugins) {
+    const pluginName = plugin.name
+    aliases.set(pluginName, pluginName)
+    aliases.set(plugin.reference.module, pluginName)
+
+    const sources = plugin.cliPlugin?.inputSources ?? []
+    if (!sources.length) continue
+
+    const pluginMap = new Map<string, CliPluginInputSource>()
+    for (const source of sources) {
+      pluginMap.set(source.id, source)
+      const existing = inputIdIndex.get(source.id) ?? []
+      existing.push(pluginName)
+      inputIdIndex.set(source.id, existing)
+    }
+    sourcesByPlugin.set(pluginName, pluginMap)
+  }
+
+  return {sourcesByPlugin, aliases, inputIdIndex}
+}
+
+function setPluginInput(
+  pluginInputs: PluginInputsByPlugin,
+  pluginName: string,
+  inputId: string,
+  value: unknown,
+) {
+  if (!pluginInputs[pluginName]) {
+    pluginInputs[pluginName] = {} as PluginInputValues
+  }
+  pluginInputs[pluginName]![inputId] = value
+}
+
+export async function resolveCliPluginInputs(
+  plugins: LoadedTemplatePlugin[],
+  rawInputs?: string[] | null,
+): Promise<PluginInputsByPlugin> {
+  const pluginInputs: PluginInputsByPlugin = {}
+  const {sourcesByPlugin, aliases, inputIdIndex} = buildInputSourceIndex(plugins)
+
+  for (const raw of rawInputs ?? []) {
+    const {pluginName, inputId, rawValue} = parsePluginInputArgument(raw)
+    const resolvedPlugin =
+      pluginName ? aliases.get(pluginName) : undefined
+
+    if (pluginName && !resolvedPlugin) {
+      throw new Error(`Unknown plugin "${pluginName}" for input "${inputId}".`)
+    }
+
+    let targetPlugin = resolvedPlugin
+    if (!targetPlugin) {
+      const matches = inputIdIndex.get(inputId) ?? []
+      if (matches.length === 1) {
+        targetPlugin = matches[0]
+      } else if (matches.length > 1) {
+        throw new Error(
+          `Plugin input "${inputId}" is ambiguous. Specify "<plugin>:${inputId}=<value>".`,
+        )
+      }
+    }
+
+    if (!targetPlugin) {
+      throw new Error(`Unknown plugin input source "${inputId}".`)
+    }
+
+    const sources = sourcesByPlugin.get(targetPlugin)
+    if (!sources?.has(inputId)) {
+      throw new Error(`Plugin "${targetPlugin}" does not define input "${inputId}".`)
+    }
+
+    const value = await parsePluginInputValue(rawValue)
+    setPluginInput(pluginInputs, targetPlugin, inputId, value)
+  }
+
+  for (const [pluginName, sources] of sourcesByPlugin.entries()) {
+    for (const [inputId, source] of sources.entries()) {
+      if (pluginInputs[pluginName]?.[inputId] !== undefined) {
+        continue
+      }
+      if (!source.env) {
+        continue
+      }
+      const envValue = process.env[source.env]
+      if (envValue === undefined) {
+        continue
+      }
+      const parsed = await parsePluginInputValue(envValue)
+      setPluginInput(pluginInputs, pluginName, inputId, parsed)
+    }
+  }
+
+  return pluginInputs
+}

--- a/apps/cli/src/utils/template-utils.ts
+++ b/apps/cli/src/utils/template-utils.ts
@@ -83,6 +83,7 @@ async function promptUserTemplateSettings(
   options?: {
     projectSettings?: ProjectSettings
     templateInstanceId?: string
+    pluginInputs?: skaffLib.PluginInputsByPlugin
   },
 ): Promise<UserTemplateSettings> {
   const rootTpl = await skaffLib.getTemplate(rootTemplateName)
@@ -112,6 +113,7 @@ async function promptUserTemplateSettings(
   const pluginsResult = await skaffLib.loadPluginsForTemplate(
     rootTpl.data.template,
     templateTypes.createReadonlyProjectContext(projectSettings),
+    {pluginInputs: options?.pluginInputs},
   )
 
   if ('error' in pluginsResult) {
@@ -196,6 +198,7 @@ export async function readUserTemplateSettings(
   options?: {
     projectSettings?: ProjectSettings
     templateInstanceId?: string
+    pluginInputs?: skaffLib.PluginInputsByPlugin
   },
 ): Promise<UserTemplateSettings> {
   if (!arg) return promptUserTemplateSettings(rootTemplateName, templateName, defaults, options)
@@ -227,6 +230,7 @@ export async function readUserTemplateSettings(
   const pluginsResult = await skaffLib.loadPluginsForTemplate(
     rootTpl.data.template,
     templateTypes.createReadonlyProjectContext(projectSettings),
+    {pluginInputs: options?.pluginInputs},
   )
 
   if ('error' in pluginsResult) {

--- a/packages/skaff-lib/src/core/plugins/plugin-loader.ts
+++ b/packages/skaff-lib/src/core/plugins/plugin-loader.ts
@@ -6,6 +6,7 @@ import type { Template } from "../templates/Template";
 import {
   BoundSettingsInputTransform,
   CliPluginContribution,
+  LoadPluginsForTemplateOptions,
   LoadedTemplatePlugin,
   NormalizedTemplatePluginConfig,
   SkaffPluginModule,
@@ -411,6 +412,7 @@ async function readGlobalConfig(
 export async function loadPluginsForTemplate(
   template: Template,
   projectContext: ReadonlyProjectContext,
+  options?: LoadPluginsForTemplateOptions,
 ): Promise<Result<LoadedTemplatePlugin[]>> {
   const normalized = normalizeTemplatePlugins(template.config.plugins);
   if (!normalized.length) {
@@ -481,10 +483,14 @@ export async function loadPluginsForTemplate(
       projectContext,
     };
 
+    const pluginInputs =
+      options?.pluginInputs?.[pluginName] ??
+      options?.pluginInputs?.[reference.module];
     const settingsTransformContext: SettingsInputTransformContext = {
       templateName: template.config.templateConfig.name,
       projectContext,
       options: reference.options,
+      pluginInputs,
     };
 
     const settingsInputTransform = buildSettingsInputTransform(

--- a/packages/skaff-lib/src/core/plugins/plugin-types.ts
+++ b/packages/skaff-lib/src/core/plugins/plugin-types.ts
@@ -502,6 +502,7 @@ export function findPluginCommand(
 
 export interface CliPluginContribution<TPrompts = CliPromptModule> {
   commands?: PluginCliCommand[];
+  inputSources?: CliPluginInputSource[];
   templateStages?: CliTemplateStage<any, TPrompts>[];
 }
 
@@ -510,6 +511,15 @@ export type CliPluginEntrypoint<TPrompts = CliPromptModule> =
   | ((input?: UiPluginFactoryInput) =>
       | CliPluginContribution<TPrompts>
       | Promise<CliPluginContribution<TPrompts>>);
+
+export interface CliPluginInputSource {
+  /** Unique identifier for this input source within the plugin */
+  id: string;
+  /** Optional description shown in CLI help or error messages */
+  description?: string;
+  /** Optional environment variable to read default input from */
+  env?: string;
+}
 
 /**
  * Context provided to web plugin getNotices function.
@@ -567,6 +577,8 @@ export interface SettingsInputTransformContext {
   projectContext: ReadonlyProjectContext;
   /** Plugin-specific options from the template configuration */
   options?: unknown;
+  /** Plugin-specific CLI inputs (parsed from flags/env) */
+  pluginInputs?: PluginInputValues;
 }
 
 /**
@@ -583,6 +595,13 @@ export type SettingsInputTransformHook = (
 export type BoundSettingsInputTransform = (
   input: unknown,
 ) => UserTemplateSettings;
+
+export type PluginInputValues = Record<string, unknown>;
+export type PluginInputsByPlugin = Record<string, PluginInputValues>;
+
+export interface LoadPluginsForTemplateOptions {
+  pluginInputs?: PluginInputsByPlugin;
+}
 
 export interface NormalizedTemplatePluginConfig {
   module: string;


### PR DESCRIPTION
### Motivation

- Provide first-class CLI-defined input channels for plugins so settings transforms can access structured inputs from flags, env vars, or files.
- Allow templates to load plugin metadata early so the CLI can parse plugin-provided input flags before settings validation.
- Ensure plugin `settingsInputTransform` hooks receive parsed plugin inputs in their context for non-interactive/batched flows.

### Description

- Added `inputSources` to `CliPluginContribution` and introduced `CliPluginInputSource`, `PluginInputValues`, `PluginInputsByPlugin`, and `LoadPluginsForTemplateOptions` in `plugin-types.ts` to model plugin-declared CLI inputs and the runtime input map.
- Plumbed `pluginInputs` into `SettingsInputTransformContext` and updated `loadPluginsForTemplate` to accept `options?: LoadPluginsForTemplateOptions` and bind per-plugin inputs into transform contexts.
- Implemented a CLI utility `resolveCliPluginInputs` in `apps/cli/src/utils/plugin-inputs.ts` to parse `--plugin-input` flags (supporting `<plugin>:<input>=<value>`, JSON, `@file` file loading, and env fallbacks) and produce a `PluginInputsByPlugin` map.
- Wired the `skaff project new` flow (`apps/cli/src/commands/project/new.ts` and `apps/cli/src/utils/template-utils.ts`) to load plugins early, accept a repeatable `--plugin-input` flag, resolve inputs via `resolveCliPluginInputs`, and pass parsed `pluginInputs` into `readUserTemplateSettings` / `loadPluginsForTemplate` so `settingsInputTransform` hooks can use them.

### Testing

- Ran the package test/build script attempt: `cd packages/skaff-lib && bun run test`, which failed during TypeScript compilation with `Cannot find module '@timonteutelink/template-types-lib'` (environment dependency issue), so automated tests did not complete successfully.
- No other automated test failures were produced by the changes themselves in this run (build-time dependency prevented full test execution).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602185031883259e47156e094a889d)